### PR TITLE
[#150015077] Fixing http auth and integrating it into ejabberd core

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,6 +20,8 @@
 
 {deps, [{lager, ".*", {git, "https://github.com/erlang-lager/lager",
                        {tag, {if_version_above, "17", "3.4.2", "3.2.1"}}}},
+        {cuesport, ".*", {git, "https://github.com/goj/cuesport.git", {branch, "master"}}},
+        {fusco, ".*", {git, "https://github.com/dcorbacho/fusco.git", {branch, "master"}}},
         {p1_utils, ".*", {git, "https://github.com/processone/p1_utils", {tag, "1.0.9"}}},
         {cache_tab, ".*", {git, "https://github.com/processone/cache_tab", {tag, "1.0.10"}}},
         {fast_tls, ".*", {git, "https://github.com/processone/fast_tls", {tag, "1.0.15"}}},

--- a/src/ejabberd_auth_http.erl
+++ b/src/ejabberd_auth_http.erl
@@ -1,0 +1,279 @@
+%%%----------------------------------------------------------------------
+%%% File    : ejabberd_auth_http.erl
+%%% Author  : Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%% Purpose : Authentication via HTTP request
+%%% Created : 23 Sep 2013 by Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%%----------------------------------------------------------------------
+
+-module(ejabberd_auth_http).
+-author('piotr.nosek@erlang-solutions.com').
+
+-behaviour(ejabberd_auth).
+
+-behaviour(ejabberd_config).
+
+%% External exports
+-export([start/1,
+         set_password/3,
+         check_password/4,
+         check_password/6,
+         try_register/3,
+         get_password/2,
+         get_password_s/2,
+         user_exists/2,
+         remove_user/2,
+         remove_user/3,
+         plain_password_required/1,
+         store_type/1,
+         login/2,
+         get_password/3,
+         opt_type/1,
+         stop/1]).
+
+-include("ejabberd.hrl").
+-include("logger.hrl").
+
+%%%----------------------------------------------------------------------
+%%% API
+%%%----------------------------------------------------------------------
+
+opt_type(auth_opts) -> fun (V) -> V end;
+opt_type(_) -> [auth_opts].
+
+-spec start(binary()) -> ok.
+start(Host) ->
+    AuthOpts = ejabberd_config:get_option({auth_opts, Host}, fun(V) -> V end),
+    {_, AuthHost} = lists:keyfind(host, 1, AuthOpts),
+    PoolSize = proplists:get_value(connection_pool_size, AuthOpts, 10),
+    Opts = proplists:get_value(connection_opts, AuthOpts, []),
+    ChildMods = [fusco],
+    ChildMFA = {fusco, start_link, [binary_to_list(AuthHost), Opts]},
+    
+    fusco:start_link(binary_to_list(AuthHost), Opts),
+    cuesport:start_link(pool_name(Host), PoolSize, ChildMods, ChildMFA),
+    ok.
+
+-spec plain_password_required(binary()) -> false.
+plain_password_required(Server) ->
+    store_type(Server) == scram.
+
+-spec store_type(binary()) -> plain | scram.
+store_type(Server) ->
+    ejabberd_auth:password_format(Server).
+
+-spec check_password(ejabberd:luser(), binary(), ejabberd:lserver(), binary()) -> boolean().
+check_password(LUser, _AuthzId, LServer, Password) ->
+    case scram2:enabled(LServer) of
+        false ->
+            case make_req(get, <<"check_password">>, LUser, LServer, Password) of
+                {ok, <<"true">>} -> true;
+                _ -> false
+            end;
+        true ->
+            {ok, true} =:= verify_scram_password(LUser, LServer, Password)
+    end.
+
+-spec check_password(ejabberd:luser(), binary(), ejabberd:lserver(), binary(), binary(), fun()) -> boolean().
+check_password(LUser, _AuthzId, LServer, Password, Digest, DigestGen) ->
+    case make_req(get, <<"get_password">>, LUser, LServer, <<"">>) of
+        {error, _} ->
+            false;
+        {ok, GotPasswd} ->
+            case scram2:enabled(LServer) of
+                true ->
+                    case scram2:deserialize(GotPasswd) of
+                        {ok, #scram{} = Scram} ->
+                            scram2:check_digest(Scram, Digest, DigestGen, Password);
+                        _ ->
+                            false
+                    end;
+                false ->
+                    check_digest(Digest, DigestGen, Password, GotPasswd)
+            end
+    end.
+
+-spec check_digest(binary(), fun(), binary(), binary()) -> boolean().
+check_digest(Digest, DigestGen, Password, Passwd) ->
+    DigRes = if
+                 Digest /= <<>> ->
+                     Digest == DigestGen(Passwd);
+                 true ->
+                     false
+             end,
+    if DigRes ->
+           true;
+       true ->
+           (Passwd == Password) and (Password /= <<>>)
+    end.
+
+
+-spec set_password(ejabberd:luser(), ejabberd:lserver(), binary()) -> ok | {error, term()}.
+set_password(LUser, LServer, Password) ->
+    PasswordFinal = case scram2:enabled(LServer) of
+                        true -> scram2:serialize(scram2:password_to_scram(
+                                                  Password, scram2:iterations(LServer)));
+                        false -> Password
+                    end,
+    case make_req(post, <<"set_password">>, LUser, LServer, PasswordFinal) of
+        {error, _} = Err -> Err;
+        _ -> ok
+    end.
+
+-spec try_register(ejabberd:luser(), ejabberd:lserver(), binary()) -> ok | {error, atom()}.
+try_register(LUser, LServer, Password) ->
+    PasswordFinal = case scram2:enabled(LServer) of
+                        true -> scram2:serialize(scram2:password_to_scram(
+                                                  Password, scram2:iterations(LServer)));
+                        false -> Password
+                    end,
+    case make_req(post, <<"register">>, LUser, LServer, PasswordFinal) of
+        {ok, created} -> ok;
+        {error, conflict} -> {error, exists};
+        Error -> Error
+    end.
+
+-spec get_password(ejabberd:luser(), ejabberd:lserver()) -> false | binary() |
+                                          {binary(), binary(), binary(), integer()}.
+get_password(LUser, LServer) ->
+    case make_req(get, <<"get_password">>, LUser, LServer, <<"">>) of
+        {error, _} ->
+            false;
+        {ok, Password} ->
+            case scram2:enabled(LServer) of
+                true ->
+                    case scram2:deserialize(Password) of
+                        {ok, #scram{} = Scram} ->
+                            scram2:scram_to_tuple(Scram);
+                        _ ->
+                            false
+                    end;
+                false ->
+                    Password
+            end
+    end.
+
+-spec get_password_s(ejabberd:luser(), ejabberd:lserver()) -> binary().
+get_password_s(User, Server) ->
+    case get_password(User, Server) of
+        Pass when is_binary(Pass) -> Pass;
+        _ -> <<>>
+    end.
+
+-spec user_exists(ejabberd:luser(), ejabberd:lserver()) -> boolean().
+user_exists(LUser, LServer) ->
+    case make_req(get, <<"user_exists">>, LUser, LServer, <<"">>) of
+        {ok, <<"true">>} -> true;
+        _ -> false
+    end.
+
+-spec remove_user(ejabberd:luser(), ejabberd:lserver()) -> ok | not_exists | not_allowed | bad_request.
+remove_user(LUser, LServer) ->
+    remove_user_req(LUser, LServer, <<"">>, <<"remove_user">>).
+
+-spec remove_user(ejabberd:luser(), ejabberd:lserver(), binary()) -> ok | not_exists | not_allowed | bad_request.
+remove_user(LUser, LServer, Password) ->
+    case scram2:enabled(LServer) of
+        false ->
+            remove_user_req(LUser, LServer, Password, <<"remove_user_validate">>);
+        true ->
+            case verify_scram_password(LUser, LServer, Password) of
+                {ok, false} ->
+                    not_allowed;
+                {ok, true} ->
+                    remove_user_req(LUser, LServer, <<"">>, <<"remove_user">>);
+                {error, Error} ->
+                    Error
+            end
+    end.
+
+-spec remove_user_req(binary(), binary(), binary(), binary()) ->
+    ok | not_exists | not_allowed | bad_request.
+remove_user_req(LUser, LServer, Password, Method) ->
+    case make_req(post, Method, LUser, LServer, Password) of
+        {error, not_allowed} -> not_allowed;
+        {error, not_found} -> not_exists;
+        {error, _} -> bad_request;
+        _ -> ok
+    end.
+
+%%%----------------------------------------------------------------------
+%%% Request maker
+%%%----------------------------------------------------------------------
+
+-spec make_req(post | get, binary(), binary(), binary(), binary()) ->
+    {ok, Body :: binary()} | {error, term()}.
+make_req(_, _, LUser, LServer, _) when LUser == error orelse LServer == error ->
+    {error, {prep_failed, LUser, LServer}};
+make_req(Method, Path, LUser, LServer, Password) -> 
+    AuthOpts = ejabberd_config:get_option({auth_opts, LServer}, fun(V) -> V end),
+    BasicAuth = case lists:keyfind(basic_auth, 1, AuthOpts) of
+                    {_, BasicAuth0} -> BasicAuth0;
+                    _ -> ""
+                end,
+    PathPrefix = case lists:keyfind(path_prefix, 1, AuthOpts) of
+                     {_, Prefix} -> Prefix;
+                     false -> <<"/">>
+                 end,
+    BasicAuth64 = base64:encode(BasicAuth),
+    LUserE = list_to_binary(http_uri:encode(binary_to_list(LUser))),
+    LServerE = list_to_binary(http_uri:encode(binary_to_list(LServer))),
+    PasswordE = list_to_binary(http_uri:encode(binary_to_list(Password))),
+    Query = <<"user=", LUserE/binary, "&server=", LServerE/binary, "&pass=", PasswordE/binary>>,
+    Header = [{<<"Authorization">>, <<"Basic ", BasicAuth64/binary>>}],
+    Connection = cuesport:get_worker(existing_pool_name(LServer)),
+
+    ?DEBUG("Making request '~s' for user ~s@~s...", [Path, LUser, LServer]),
+    ?DEBUG("With connection ~p  PathPrefix ~p   Path   ~p       Method  ~p         Query ~p", [Connection, PathPrefix, Path, Method, Query]),
+    {ok, {{Code, _Reason}, _RespHeaders, RespBody, _, _}} = case Method of
+        get -> fusco:request(Connection, <<PathPrefix/binary, Path/binary, "?", Query/binary>>,
+                             "GET", Header, "", 2, 5000);
+        post -> fusco:request(Connection, <<PathPrefix/binary, Path/binary>>,
+                              "POST", Header, Query, 2, 5000)
+    end,
+
+    ?DEBUG("Request result: ~s: ~p", [Code, RespBody]),
+    case Code of
+        <<"409">> -> {error, conflict};
+        <<"404">> -> {error, not_found};
+        <<"401">> -> {error, not_authorized};
+        <<"403">> -> {error, not_allowed};
+        <<"400">> -> {error, RespBody};
+        <<"204">> -> {ok, <<"">>};
+        <<"201">> -> {ok, created};
+        <<"200">> -> {ok, RespBody}
+    end.
+
+%%%----------------------------------------------------------------------
+%%% Other internal functions
+%%%----------------------------------------------------------------------
+-spec pool_name(binary()) -> atom().
+pool_name(Host) ->
+    list_to_atom("ejabberd_auth_http_" ++ binary_to_list(Host)).
+
+-spec existing_pool_name(binary()) -> atom().
+existing_pool_name(Host) ->
+    list_to_existing_atom("ejabberd_auth_http_" ++ binary_to_list(Host)).
+
+-spec verify_scram_password(binary(), binary(), binary()) ->
+    {ok, boolean()} | {error, bad_request | not_exists}.
+verify_scram_password(LUser, LServer, Password) ->
+    case make_req(get, <<"get_password">>, LUser, LServer, <<"">>) of
+        {ok, RawPassword} ->
+            case scram2:deserialize(RawPassword) of
+                {ok, #scram{} = ScramRecord} ->
+                    {ok, scram2:check_password(Password, ScramRecord)};
+                _ ->
+                    {error, bad_request}
+            end;
+        _ ->
+            {error, not_exists}
+    end.
+
+login(_User, _Server) ->
+    erlang:error(not_implemented).
+
+get_password(_User, _Server, _DefaultValue) ->
+    erlang:error(not_implemented).
+
+stop(_Host) ->
+    ok.

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -919,15 +919,21 @@ is_behaviour(Behav, Mod) ->
 v_db(Mod, internal) -> v_db(Mod, mnesia);
 v_db(Mod, odbc) -> v_db(Mod, sql);
 v_db(Mod, Type) ->
-    case ejabberd_db_modules:is_known(Mod) of
-	true ->
-	    case ejabberd_db_modules:Mod(Type) of
-		{ok, _} -> Type;
-		_ -> erlang:error(badarg)
-	    end;
-	false ->
-	    erlang:error(badarg)
+    case Type == http of
+        true ->
+            Type;
+        false ->
+            case ejabberd_db_modules:is_known(Mod) of
+        	true ->
+        	    case ejabberd_db_modules:Mod(Type) of
+        		{ok, _} -> Type;
+        		_ -> erlang:error(badarg)
+        	    end;
+        	false ->
+        	    erlang:error(badarg)
+            end
     end.
+
 
 -spec v_dbs(module()) -> [atom()].
 

--- a/src/scram2.erl
+++ b/src/scram2.erl
@@ -1,0 +1,198 @@
+%%%----------------------------------------------------------------------
+%%% File    : scram.erl
+%%% Author  : Stephen Röttger <stephen.roettger@googlemail.com>
+%%% Purpose : SCRAM (RFC 5802)
+%%% Created : 7 Aug 2011 by Stephen Röttger <stephen.roettger@googlemail.com>
+%%%
+%%%
+%%% ejabberd, Copyright (C) 2002-2013   ProcessOne
+%%%
+%%% This program is free software; you can redistribute it and/or
+%%% modify it under the terms of the GNU General Public License as
+%%% published by the Free Software Foundation; either version 2 of the
+%%% License, or (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%%% General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with this program; if not, write to the Free Software
+%%% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+%%% 02111-1307 USA
+%%%
+%%%----------------------------------------------------------------------
+
+-module(scram2).
+
+-author('stephen.roettger@googlemail.com').
+
+-include("ejabberd.hrl").
+-include("logger.hrl").
+
+%% External exports
+%% ejabberd doesn't implement SASLPREP, so we use the similar RESOURCEPREP instead
+-export([ % Core SCRAM functions
+         salted_password/3,
+         stored_key/1,
+         server_key/1,
+         server_signature/2,
+         client_signature/2,
+         client_key/1,
+         client_key/2]).
+
+-export([
+         enabled/1,
+         iterations/0,
+         iterations/1,
+         password_to_scram/1,
+         password_to_scram/2,
+         check_password/2,
+         check_digest/4
+        ]).
+
+-export([serialize/1, deserialize/1]).
+
+-export([scram_to_tuple/1]).
+
+-define(SALT_LENGTH, 16).
+-define(SCRAM_SERIAL_PREFIX, "==SCRAM==,").
+
+-spec salted_password(binary(), binary(), non_neg_integer()) -> binary().
+salted_password(Password, Salt, IterationCount) ->
+    hi(jlib:resourceprep(Password), Salt, IterationCount).
+
+-spec client_key(binary()) -> binary().
+client_key(SaltedPassword) ->
+    crypto_hmac(sha, SaltedPassword, <<"Client Key">>).
+
+-spec stored_key(binary()) -> binary().
+stored_key(ClientKey) -> crypto:hash(sha, ClientKey).
+
+-spec server_key(binary()) -> binary().
+server_key(SaltedPassword) ->
+    crypto_hmac(sha, SaltedPassword, <<"Server Key">>).
+
+-spec client_signature(binary(), binary()) -> binary().
+client_signature(StoredKey, AuthMessage) ->
+    crypto_hmac(sha, StoredKey, AuthMessage).
+
+-spec client_key(binary(), binary()) -> binary().
+client_key(ClientProof, ClientSignature) ->
+    list_to_binary(lists:zipwith(fun (X, Y) -> X bxor Y end,
+				 binary_to_list(ClientProof),
+				 binary_to_list(ClientSignature))).
+
+-spec server_signature(binary(), binary()) -> binary().
+server_signature(ServerKey, AuthMessage) ->
+    crypto_hmac(sha, ServerKey, AuthMessage).
+
+hi(Password, Salt, IterationCount) ->
+    U1 = crypto_hmac(sha, Password, <<Salt/binary, 0, 0, 0, 1>>),
+    list_to_binary(lists:zipwith(fun (X, Y) -> X bxor Y end,
+				 binary_to_list(U1),
+				 binary_to_list(hi_round(Password, U1,
+							 IterationCount - 1)))).
+
+hi_round(Password, UPrev, 1) ->
+    crypto_hmac(sha, Password, UPrev);
+hi_round(Password, UPrev, IterationCount) ->
+    U = crypto_hmac(sha, Password, UPrev),
+    list_to_binary(lists:zipwith(fun (X, Y) -> X bxor Y end,
+				 binary_to_list(U),
+				 binary_to_list(hi_round(Password, U,
+							 IterationCount - 1)))).
+
+
+enabled(Host) ->
+    case ejabberd_config:get_option({auth_opts, Host}, fun(V) -> V end) of
+        undefined ->
+            false;
+        AuthOpts ->
+            {password_format, scram} == lists:keyfind(password_format, 1, AuthOpts)
+    end.
+
+iterations() -> ?SCRAM_DEFAULT_ITERATION_COUNT.
+
+iterations(Host) ->
+    case ejabberd_config:get_option({auth_opts, Host}, fun(V) -> V end) of
+        undefined ->
+            iterations();
+        AuthOpts ->
+            case lists:keyfind(scram_iterations, 1, AuthOpts) of
+                false -> iterations();
+                {_, Iterations} -> Iterations
+            end
+    end.
+
+password_to_scram(Password) ->
+    password_to_scram(Password, ?SCRAM_DEFAULT_ITERATION_COUNT).
+
+password_to_scram(#scram{} = Password, _) ->
+    Password;
+password_to_scram(Password, IterationCount) ->
+    Salt = crypto:rand_bytes(?SALT_LENGTH),
+    SaltedPassword = salted_password(Password, Salt, IterationCount),
+    StoredKey = stored_key(scram2:client_key(SaltedPassword)),
+    ServerKey = server_key(SaltedPassword),
+    #scram{storedkey = base64:encode(StoredKey),
+           serverkey = base64:encode(ServerKey),
+           salt = base64:encode(Salt),
+           iterationcount = IterationCount}.
+
+check_password(Password, Scram) ->
+    IterationCount = Scram#scram.iterationcount,
+    Salt = base64:decode(Scram#scram.salt),
+    SaltedPassword = salted_password(Password, Salt, IterationCount),
+    StoredKey = stored_key(client_key(SaltedPassword)),
+    (base64:decode(Scram#scram.storedkey) == StoredKey).
+
+serialize(#scram{storedkey = StoredKey, serverkey = ServerKey,
+                     salt = Salt, iterationcount = IterationCount})->
+    IterationCountBin = integer_to_binary(IterationCount),
+    << <<?SCRAM_SERIAL_PREFIX>>/binary,
+       StoredKey/binary,$,,ServerKey/binary,
+       $,,Salt/binary,$,,IterationCountBin/binary>>.
+
+deserialize(<<?SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
+    case catch binary:split(Serialized, <<",">>, [global]) of
+        [StoredKey, ServerKey,Salt,IterationCount] ->
+            {ok, #scram{storedkey = StoredKey,
+                        serverkey = ServerKey,
+                        salt = Salt,
+                        iterationcount = binary_to_integer(IterationCount)}};
+        _ ->
+            ?WARNING_MSG("Incorrect serialized SCRAM: ~p, ~p", [Serialized]),
+            {error, incorrect_scram}
+    end;
+deserialize(Bin) ->
+    ?WARNING_MSG("Corrupted serialized SCRAM: ~p, ~p", [Bin]),
+    {error, corrupted_scram}.
+
+-spec scram_to_tuple(scram()) -> {binary(), binary(), binary(), non_neg_integer()}.
+scram_to_tuple(Scram) ->
+    {base64:decode(Scram#scram.storedkey),
+     base64:decode(Scram#scram.serverkey),
+     base64:decode(Scram#scram.salt),
+     Scram#scram.iterationcount}.
+
+-spec check_digest(scram(), binary(), fun(), binary()) -> boolean().
+check_digest(#scram{storedkey = StoredKey}, Digest, DigestGen, Password) ->
+    Passwd = jlib:decode_base64(StoredKey),
+    DigRes = if Digest /= <<"">> ->
+	      Digest == DigestGen(Passwd);
+	      true -> false
+	   end,
+    if DigRes -> true;
+       true -> (Passwd == Password) and (Password /= <<"">>)
+    end.
+
+
+-ifdef(no_crypto_hmac).
+crypto_hmac(sha, Key, Data) ->
+    crypto:sha_mac(Key, Data).
+-else.
+crypto_hmac(sha, Key, Data) ->
+    crypto:hmac(sha, Key, Data).
+-endif.


### PR DESCRIPTION
In http_auth I had to modify the startup method. The supervision tree is slightly different but it shouldn't pose problems. I dunno why using the ejabberd_sup was causing issues, but I switched it to using direct start_links and there is still a supervisor in the chain, so it should be okay.