### PR TITLE
[#156666629] Joining a Room will Create the Room When It Does Not Exist

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1852,6 +1852,22 @@ add_new_user(From, Nick, Packet, StateData) ->
 		Nodes = get_subscription_nodes(Packet),
 		NewStateData =
 		      if not IsSubscribeRequest ->
+			      ServerHost = StateData#state.server_host,
+			      Room = StateData#state.room,
+			      Host = StateData#state.host,
+			      DefRoomOpts = gen_mod:get_module_opt(ServerHost, mod_muc, default_room_options, []),
+			      Access = gen_mod:get_module_opt(ServerHost, mod_muc, access, all),
+			      HistorySize = gen_mod:get_module_opt(ServerHost, mod_muc, history_size, 20),
+			      RoomShaper = gen_mod:get_module_opt(ServerHost, mod_muc, room_shaper, none),
+			      QueueType = gen_mod:get_module_opt(ServerHost, mod_muc, queue_type,
+			       ejabberd_config:default_queue_type(ServerHost)),
+			      RMod = gen_mod:ram_db_mod(ServerHost, ?MODULE),
+			      case mod_muc:check_create_roomid(ServerHost, Room) of
+			       true ->
+			      	 {ok, Pid} = mod_muc:start_new_room(
+			      		 Host, ServerHost, Access, Room, HistorySize, RoomShaper, From, Nick, DefRoomOpts, QueueType),
+			      	 RMod:register_online_room(ServerHost, Room, Host, Pid)
+			      end,
 			      NewState = add_user_presence(
 					   From, Packet,
 					   add_online_user(From, Nick, Role,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1852,18 +1852,18 @@ add_new_user(From, Nick, Packet, StateData) ->
 		Nodes = get_subscription_nodes(Packet),
 		NewStateData =
 		      if not IsSubscribeRequest ->
-			      ServerHost = StateData#state.server_host,
-			      Room = StateData#state.room,
-			      Host = StateData#state.host,
-			      DefRoomOpts = gen_mod:get_module_opt(ServerHost, mod_muc, default_room_options, []),
-			      Access = gen_mod:get_module_opt(ServerHost, mod_muc, access, all),
-			      HistorySize = gen_mod:get_module_opt(ServerHost, mod_muc, history_size, 20),
-			      RoomShaper = gen_mod:get_module_opt(ServerHost, mod_muc, room_shaper, none),
-			      QueueType = gen_mod:get_module_opt(ServerHost, mod_muc, queue_type,
-			       ejabberd_config:default_queue_type(ServerHost)),
-			      RMod = gen_mod:ram_db_mod(ServerHost, ?MODULE),
 			      case mod_muc:check_create_roomid(ServerHost, Room) of
 			       true ->
+			      	 ServerHost = StateData#state.server_host,
+			      	 Room = StateData#state.room,
+			      	 Host = StateData#state.host,
+			      	 DefRoomOpts = gen_mod:get_module_opt(ServerHost, mod_muc, default_room_options, []),
+			      	 Access = gen_mod:get_module_opt(ServerHost, mod_muc, access, all),
+			      	 HistorySize = gen_mod:get_module_opt(ServerHost, mod_muc, history_size, 20),
+			      	 RoomShaper = gen_mod:get_module_opt(ServerHost, mod_muc, room_shaper, none),
+			      	 QueueType = gen_mod:get_module_opt(ServerHost, mod_muc, queue_type,
+			      		 ejabberd_config:default_queue_type(ServerHost)),
+			      	 RMod = gen_mod:ram_db_mod(ServerHost, ?MODULE),
 			      	 {ok, Pid} = mod_muc:start_new_room(
 			      		 Host, ServerHost, Access, Room, HistorySize, RoomShaper, From, Nick, DefRoomOpts, QueueType),
 			      	 RMod:register_online_room(ServerHost, Room, Host, Pid)

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1852,10 +1852,10 @@ add_new_user(From, Nick, Packet, StateData) ->
 		Nodes = get_subscription_nodes(Packet),
 		NewStateData =
 		      if not IsSubscribeRequest ->
+			      ServerHost = StateData#state.server_host,
+			      Room = StateData#state.room,
 			      case mod_muc:check_create_roomid(ServerHost, Room) of
 			       true ->
-			      	 ServerHost = StateData#state.server_host,
-			      	 Room = StateData#state.room,
 			      	 Host = StateData#state.host,
 			      	 DefRoomOpts = gen_mod:get_module_opt(ServerHost, mod_muc, default_room_options, []),
 			      	 Access = gen_mod:get_module_opt(ServerHost, mod_muc, access, all),


### PR DESCRIPTION
Joining a room is nested inside of the `add_online_user` in `add_user_presence(From, Packet, add_online_user(From, Nick, Role, StateData))` so I added the create room logic which checks if the room is in the DB and restores it from those configs or creates a new room entirely

@mpope9 