### PR TITLE
[#156666629] Create Room When Joining if it Does Not Exist

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -64,7 +64,9 @@
 	 iq_set_register_info/5,
 	 count_online_rooms_by_user/3,
 	 get_online_rooms_by_user/3,
-	 can_use_nick/4]).
+	 can_use_nick/4,
+	 check_create_roomid/2,
+	 start_new_room/10]).
 
 -export([init/1, handle_call/3, handle_cast/2,
 	 handle_info/2, terminate/2, code_change/3,


### PR DESCRIPTION
Reverted changes yesterday as it caused chat to be broken and found in the logs that the methods were undefined, causing the server to crash. Added those methods to the export so mod_muc_room can use these methods from mod_muc

@mpope9 
@MattFoley 