### PR TITLE
[#156666629] Send Signal that Room was Created

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1865,7 +1865,8 @@ add_new_user(From, Nick, Packet, StateData) ->
 			      		 ejabberd_config:default_queue_type(ServerHost)),
 			      	 {ok, Pid} = mod_muc:start_new_room(
 			      		 Host, ServerHost, Access, Room, HistorySize, RoomShaper, From, Nick, DefRoomOpts, QueueType),
-			      	 mod_muc:register_online_room(Room, Host, Pid);
+			      	 mod_muc:register_online_room(Room, Host, Pid),
+			      	 route(Pid, Packet);
 			       {_, _} -> ok
 			      end,
 			      NewState = add_user_presence(


### PR DESCRIPTION
Looking at `mod_muc`, after it registers the room it routes the packet to signal that the room was created, so will do the same here.

@mpope9 
@MattFoley 