### PR TITLE
[#155907078] Reload Messages from MAM on Recreated Rooms

### DIFF
--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -37,7 +37,7 @@
 	 remove_user/2, remove_room/3, mod_opt_type/1, muc_process_iq/2,
 	 muc_filter_message/3, message_is_archived/3, delete_old_messages/2,
 	 get_commands_spec/0, msg_to_el/4, get_room_config/4, set_room_option/3,
-	 offline_message/1, export/1, select_and_send/5, limit_max/2]).
+	 offline_message/1, export/1, select_and_send/5]).
 
 -include("xmpp.hrl").
 -include("logger.hrl").

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -37,7 +37,7 @@
 	 remove_user/2, remove_room/3, mod_opt_type/1, muc_process_iq/2,
 	 muc_filter_message/3, message_is_archived/3, delete_old_messages/2,
 	 get_commands_spec/0, msg_to_el/4, get_room_config/4, set_room_option/3,
-	 offline_message/1, export/1]).
+	 offline_message/1, export/1, select_and_send/5, limit_max/2]).
 
 -include("xmpp.hrl").
 -include("logger.hrl").

--- a/src/mod_mam_sql.erl
+++ b/src/mod_mam_sql.erl
@@ -146,6 +146,7 @@ select(LServer, JidRequestor, #jid{luser = LUser} = JidArchive,
 	       {groupchat, _Role, _MUCState} -> jid:encode(JidArchive)
 	   end,
     {Query, CountQuery} = make_sql_query(User, LServer, MAMQuery, RSM),
+    ?DEBUG("Logging for retriving with mam with query = ~p and user = ~p", [Query, User]),
     % TODO from XEP-0313 v0.2: "To conserve resources, a server MAY place a
     % reasonable limit on how many stanzas may be pushed to a client in one
     % request. If a query returns a number of stanzas greater than this limit

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1869,9 +1869,8 @@ add_new_user(From, Nick, Packet, StateData) ->
 			      ?DEBUG("Logging for joining room = ~p with history = ~p", [To, History]),
 			      case History == [] of
 			      	true ->
-			      		NewRSM = mod_mam:limit_max(RSM, NewState),
-			      		?DEBUG("Logging for restoring messages on host = ~s, IQ = ~p, RSM = ~p, newRSM = ~p ", [ServerHost, IQ, RSM, NewRSM]),
-			      		mod_mam:select_and_send(ServerHost, Query, NewRSM, IQ, Type);
+			      		?DEBUG("Logging for restoring messages on host = ~s, IQ = ~p, RSM = ~p", [ServerHost, IQ, RSM]),
+			      		mod_mam:select_and_send(ServerHost, Query, RSM, IQ, Type);
 			      	false -> send_history(From, History, NewState)
 			      end,
 			      send_subject(From, StateData),


### PR DESCRIPTION
Querying DB when history is empty, and sending event that history has been retrieved. Added logs while I'm at it.

@mpope9 
@MattFoley 