### PR TITLE
[#156709610] Feature add subscribers

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -833,12 +833,11 @@ opts_to_binary(Opts) ->
       end, Opts).
 
 %%-spec db_subscribe(jid(), jid()) -> ok.
-db_subscribe(LServer, LBareJID, Room)  ->
+db_subscribe(ServerHost, LBareJID, Room)  ->
   ?DEBUG("!!!!!!!", []),
-  PrepJID = jid:nameprep(LBareJID),
-  PrepRoom = jid:nameprep(Room),
+  LServer = jid:nameprep(ServerHost),
   Mod = gen_mod:db_mod(LServer, ?MODULE),
-  Mod:db_subscribe(LServer, PrepJID, PrepRoom),
+  Mod:db_subscribe(LServer, LBareJID, Room),
   ok.
 
 export(LServer) ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -833,11 +833,11 @@ opts_to_binary(Opts) ->
       end, Opts).
 
 %%-spec db_subscribe(jid(), jid()) -> ok.
-db_subscribe(ServerHost, LBareJID, Room)  ->
-  ?DEBUG("!!!!!!!", []),
+db_subscribe(ServerHost, LBareJID, RoomJID)  ->
+  LBareRoomJID = jid:tolower(jid:remove_resource(RoomJID)),
   LServer = jid:nameprep(ServerHost),
   Mod = gen_mod:db_mod(LServer, ?MODULE),
-  Mod:db_subscribe(LServer, LBareJID, Room),
+  Mod:db_subscribe(LServer, LBareJID, LBareRoomJID),
   ok.
 
 export(LServer) ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -832,7 +832,6 @@ opts_to_binary(Opts) ->
               Opt
       end, Opts).
 
-%%-spec db_subscribe(jid(), jid()) -> ok.
 db_subscribe(ServerHost, LBareJID, RoomJID)  ->
   LBareRoomJID = jid:tolower(jid:remove_resource(RoomJID)),
   LServer = jid:nameprep(ServerHost),

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -64,7 +64,8 @@
 	 iq_set_register_info/5,
 	 count_online_rooms_by_user/3,
 	 get_online_rooms_by_user/3,
-	 can_use_nick/4]).
+	 can_use_nick/4,
+   db_subscribe/2]).
 
 -export([init/1, handle_call/3, handle_cast/2,
 	 handle_info/2, terminate/2, code_change/3,
@@ -114,6 +115,7 @@ start(Host, Opts) ->
 
 stop(Host) ->
     Rooms = shutdown_rooms(Host),
+    ejabberd_hooks:delete(trigger_db_subscription, Host, ?MODULE, db_subscribe, 10),
     gen_mod:stop_child(?MODULE, Host),
     {wait, Rooms}.
 
@@ -240,6 +242,8 @@ init([Host, Opts]) ->
 	      ejabberd_router:register_route(MyHost, Host)
         %% Permenent rooms are not loaded into memory.
       end, MyHosts),
+    %% Hook added to save subscription to DB.
+    ejabberd_hooks:add(trigger_db_subscription, Host, ?MODULE, db_subscribe, 10),
     {ok, State}.
 
 handle_call(stop, _From, State) ->
@@ -827,6 +831,13 @@ opts_to_binary(Opts) ->
          (Opt) ->
               Opt
       end, Opts).
+
+-spec db_subscribe(jid(), jid()) -> ok.
+db_subscribe(JID, Room)  ->
+  LServer = maps:get(lserver, JID),
+  Mod = gen_mod:db_mod(LServer, ?MODULE),
+  Mod:db_subscribe(LServer, JID, Room),
+  ok.
 
 export(LServer) ->
     Mod = gen_mod:db_mod(LServer, ?MODULE),

--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -40,6 +40,7 @@
 -export([start_link/2, init/1, handle_cast/2, handle_call/3, handle_info/2,
 	 terminate/2, code_change/3]).
 -export([need_transform/1, transform/1]).
+-export([db_subscribe/2]).
 
 -include("mod_muc.hrl").
 -include("logger.hrl").
@@ -62,6 +63,9 @@ init(Host, Opts) ->
 start_link(Host, Opts) ->
     Name = gen_mod:get_module_proc(Host, ?MODULE),
     gen_server:start_link({local, Name}, ?MODULE, [Host, Opts], []).
+
+db_subscribe(_JID, _Room) ->
+  {error, not_implemented}.
 
 store_room(_LServer, Host, Name, Opts) ->
     F = fun () ->

--- a/src/mod_muc_riak.erl
+++ b/src/mod_muc_riak.erl
@@ -36,6 +36,7 @@
 	 count_online_rooms_by_user/3, get_online_rooms_by_user/3]).
 -export([set_affiliation/6, set_affiliations/4, get_affiliation/5,
 	 get_affiliations/3, search_affiliation/4]).
+-export([db_subscribe/2]).
 
 -include("jid.hrl").
 -include("mod_muc.hrl").
@@ -50,6 +51,9 @@ store_room(_LServer, Host, Name, Opts) ->
     {atomic, ejabberd_riak:put(#muc_room{name_host = {Name, Host},
                                          opts = Opts},
 			       muc_room_schema())}.
+
+db_subscribe(_JID, _Host) ->
+  {error, not_implemented}.
 
 restore_room(_LServer, Host, Name) ->
     case ejabberd_riak:get(muc_room, muc_room_schema(), {Name, Host}) of

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1589,6 +1589,8 @@ update_online_user(JID, #user{nick = Nick} = User, StateData) ->
 set_subscriber(JID, Nick, Nodes, StateData) ->
     BareJID = jid:remove_resource(JID),
     LBareJID = jid:tolower(BareJID),
+    ejabberd_hooks:run(db_subscribe, [StateData#state.server_host, LBareJID, StateData#state.room]),
+    ?DEBUG("??????", []),
     Subscribers = ?DICT:store(LBareJID,
 			      #subscriber{jid = BareJID,
 					  nick = Nick,
@@ -1597,7 +1599,6 @@ set_subscriber(JID, Nick, Nodes, StateData) ->
     Nicks = ?DICT:store(Nick, [LBareJID], StateData#state.subscriber_nicks),
     NewStateData = StateData#state{subscribers = Subscribers,
 				   subscriber_nicks = Nicks},
-    ejabberd_hooks:run(db_subscribe, LBareJID, StateData#state.room),
     store_room(NewStateData),
     NewStateData.
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1590,7 +1590,6 @@ set_subscriber(JID, Nick, Nodes, StateData) ->
     BareJID = jid:remove_resource(JID),
     LBareJID = jid:tolower(BareJID),
     ejabberd_hooks:run(db_subscribe, [StateData#state.server_host, LBareJID, StateData#state.jid]),
-    ?DEBUG("??????", []),
     Subscribers = ?DICT:store(LBareJID,
 			      #subscriber{jid = BareJID,
 					  nick = Nick,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1597,6 +1597,7 @@ set_subscriber(JID, Nick, Nodes, StateData) ->
     Nicks = ?DICT:store(Nick, [LBareJID], StateData#state.subscriber_nicks),
     NewStateData = StateData#state{subscribers = Subscribers,
 				   subscriber_nicks = Nicks},
+    ejabberd_hooks:run(db_subscribe, LBareJID, StateData#state.room),
     store_room(NewStateData),
     NewStateData.
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1589,7 +1589,7 @@ update_online_user(JID, #user{nick = Nick} = User, StateData) ->
 set_subscriber(JID, Nick, Nodes, StateData) ->
     BareJID = jid:remove_resource(JID),
     LBareJID = jid:tolower(BareJID),
-    ejabberd_hooks:run(db_subscribe, [StateData#state.server_host, LBareJID, StateData#state.room]),
+    ejabberd_hooks:run(db_subscribe, [StateData#state.server_host, LBareJID, StateData#state.jid]),
     ?DEBUG("??????", []),
     Subscribers = ?DICT:store(LBareJID,
 			      #subscriber{jid = BareJID,

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -65,8 +65,6 @@ db_subscribe(LServer, LBareJID, LBareRoomJID) ->
     SRoomJID = jid:encode(LBareRoomJID),
     F = fun () ->
         ejabberd_sql:sql_query_t(
-                  %%?SQL("insert into subscriptions (name, subscription) values( "
-                  %%     "%(SJID)s, %(Room)s);"))
                   ?SQL("insert into subscriptions (name, subscription) "
                        "select %(SJID)s, %(SRoomJID)s from DUAL "
                        "where not exists ("

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -39,6 +39,7 @@
 	 count_online_rooms_by_user/3, get_online_rooms_by_user/3]).
 -export([set_affiliation/6, set_affiliations/4, get_affiliation/5,
 	 get_affiliations/3, search_affiliation/4]).
+-export([db_subscribe/3]).
 
 -include("jid.hrl").
 -include("mod_muc.hrl").
@@ -55,6 +56,13 @@ init(Host, Opts) ->
 	_ ->
 	    ok
     end.
+
+db_subscribe(LServer, JID, Room) ->
+	  F = fun () ->
+      ejabberd_sql:sql_query_t(
+        ?SQL(""))
+  end,
+  ejabberd_sql:sql_transaction(LServer, F).
 
 store_room(LServer, Host, Name, Opts) ->
     SOpts = misc:term_to_expr(Opts),

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -64,8 +64,13 @@ db_subscribe(LServer, LBareJID, Room) ->
     SJID = jid:encode(LBareJID),
     F = fun () ->
         ejabberd_sql:sql_query_t(
-                  ?SQL("insert into subscriptions (name, subscription) values( "
-                       "%(SJID)s, %(Room)s);"))
+                  %%?SQL("insert into subscriptions (name, subscription) values( "
+                  %%     "%(SJID)s, %(Room)s);"))
+                  ?SQL("insert into subscriptions (name, subscription) "
+                       "select %(SJID)s, %(Room)s from DUAL "
+                       "where not exists ("
+                       "   select 1 from subscriptions "
+                       "   where name=%(SJID)s AND subscription=%(Room)s);"))
     end,
     ejabberd_sql:sql_transaction(LServer, F).
 

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -62,11 +62,11 @@ db_subscribe(LServer, LBareJID, LBareRoomJID) ->
     SRoomJID = jid:encode(LBareRoomJID),
     F = fun () ->
         ejabberd_sql:sql_query_t(
-                  ?SQL("insert into subscription (name, subscription) "
+                  ?SQL("insert into subscription (jid, room) "
                        "select %(SJID)s, %(SRoomJID)s from DUAL "
                        "where not exists ("
                        "   select 1 from subscription "
-                       "   where name=%(SJID)s AND subscription=%(SRoomJID)s);"))
+                       "   where jid=%(SJID)s AND room=%(SRoomJID)s);"))
     end,
     ejabberd_sql:sql_transaction(LServer, F).
 

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -65,10 +65,10 @@ db_subscribe(LServer, LBareJID, LBareRoomJID) ->
     SRoomJID = jid:encode(LBareRoomJID),
     F = fun () ->
         ejabberd_sql:sql_query_t(
-                  ?SQL("insert into subscriptions (name, subscription) "
+                  ?SQL("insert into subscription (name, subscription) "
                        "select %(SJID)s, %(SRoomJID)s from DUAL "
                        "where not exists ("
-                       "   select 1 from subscriptions "
+                       "   select 1 from subscription "
                        "   where name=%(SJID)s AND subscription=%(SRoomJID)s);"))
     end,
     ejabberd_sql:sql_transaction(LServer, F).

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -57,12 +57,15 @@ init(Host, Opts) ->
 	    ok
     end.
 
+%% Select the JID from the DB.  If it does not exist, create the row.  Otherwise,
+%% concat the current list of subscriptions with the new one.  Lets hope this doesn't
+%% get too long, it is a medium text after all.
 db_subscribe(LServer, JID, Room) ->
-	  F = fun () ->
-      ejabberd_sql:sql_query_t(
-        ?SQL(""))
-  end,
-  ejabberd_sql:sql_transaction(LServer, F).
+    F = fun () ->
+        ejabberd_sql:sql_query_t(
+                  ?SQL("insert into subscriptions (name, subscriber_list) values(%(JID)s, %(Room)s)"))
+    end,
+    ejabberd_sql:sql_transaction(LServer, F).
 
 store_room(LServer, Host, Name, Opts) ->
     SOpts = misc:term_to_expr(Opts),

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -60,10 +60,12 @@ init(Host, Opts) ->
 %% Select the JID from the DB.  If it does not exist, create the row.  Otherwise,
 %% concat the current list of subscriptions with the new one.  Lets hope this doesn't
 %% get too long, it is a medium text after all.
-db_subscribe(LServer, JID, Room) ->
+db_subscribe(LServer, LBareJID, Room) ->
+    SJID = jid:encode(LBareJID),
     F = fun () ->
         ejabberd_sql:sql_query_t(
-                  ?SQL("insert into subscriptions (name, subscriber_list) values(%(JID)s, %(Room)s)"))
+                  ?SQL("insert into subscriptions (name, subscription) values( "
+                       "%(SJID)s, %(Room)s);"))
     end,
     ejabberd_sql:sql_transaction(LServer, F).
 

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -57,9 +57,6 @@ init(Host, Opts) ->
 	    ok
     end.
 
-%% Select the JID from the DB.  If it does not exist, create the row.  Otherwise,
-%% concat the current list of subscriptions with the new one.  Lets hope this doesn't
-%% get too long, it is a medium text after all.
 db_subscribe(LServer, LBareJID, LBareRoomJID) ->
     SJID = jid:encode(LBareJID),
     SRoomJID = jid:encode(LBareRoomJID),

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -60,17 +60,18 @@ init(Host, Opts) ->
 %% Select the JID from the DB.  If it does not exist, create the row.  Otherwise,
 %% concat the current list of subscriptions with the new one.  Lets hope this doesn't
 %% get too long, it is a medium text after all.
-db_subscribe(LServer, LBareJID, Room) ->
+db_subscribe(LServer, LBareJID, LBareRoomJID) ->
     SJID = jid:encode(LBareJID),
+    SRoomJID = jid:encode(LBareRoomJID),
     F = fun () ->
         ejabberd_sql:sql_query_t(
                   %%?SQL("insert into subscriptions (name, subscription) values( "
                   %%     "%(SJID)s, %(Room)s);"))
                   ?SQL("insert into subscriptions (name, subscription) "
-                       "select %(SJID)s, %(Room)s from DUAL "
+                       "select %(SJID)s, %(SRoomJID)s from DUAL "
                        "where not exists ("
                        "   select 1 from subscriptions "
-                       "   where name=%(SJID)s AND subscription=%(Room)s);"))
+                       "   where name=%(SJID)s AND subscription=%(SRoomJID)s);"))
     end,
     ejabberd_sql:sql_transaction(LServer, F).
 


### PR DESCRIPTION
This PR is the start of persistent subscription lists.

Originally the plan was to save these in a blob, but then the issue arose that each time a user logged in we'd have to loop through the blob to see if appending was needed.  I have chosen to go with the multi row approach, because of this.

The SQL query ensures that only one entry per subscription.

Some background: each muc room is a process.  The 'muc manager' is its own process.  When a subscription request comes it, I create a hook for the muc manager.  The muc room calls the hook and the manager stores the result in the database.

Only implemented the sql, added error returns if other databases are attempted to be used.

### Testing

Create a room with a friend.
Saw two rows were created.
Stopped the server.
Rows still exist.
Started the server.
Reopened the muc room.
No extra entry.

@aghchan 
@kkaminski 