### PR TITLE
[#156709589] Subscriptions retrieved and displayed

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -689,17 +689,10 @@ get_room_disco_item({Name, Host, Pid}, Query) ->
     end.
 
 get_subscribed_rooms(ServerHost, Host, From) ->
-    Rooms = get_online_rooms(ServerHost, Host),
-    BareFrom = jid:remove_resource(From),
-    lists:flatmap(
-      fun({Name, _, Pid}) ->
-	      case p1_fsm:sync_send_all_state_event(Pid, {is_subscribed, BareFrom}) of
-		  true -> [jid:make(Name, Host)];
-		  false -> []
-	      end;
-	 (_) ->
-	      []
-      end, Rooms).
+    LServer = jid:nameprep(ServerHost),
+    LBareJID = jid:tolower(jid:remove_resource(From)),
+    Mod = gen_mod:db_mod(LServer, ?MODULE),
+    Mod:get_db_subscribers(LServer, LBareJID).
 
 get_nick(ServerHost, Host, From) ->
     LServer = jid:nameprep(ServerHost),

--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -40,7 +40,7 @@
 -export([start_link/2, init/1, handle_cast/2, handle_call/3, handle_info/2,
 	 terminate/2, code_change/3]).
 -export([need_transform/1, transform/1]).
--export([db_subscribe/2]).
+-export([db_subscribe/2, get_db_subscribers/2]).
 
 -include("mod_muc.hrl").
 -include("logger.hrl").
@@ -66,6 +66,9 @@ start_link(Host, Opts) ->
 
 db_subscribe(_JID, _Room) ->
   {error, not_implemented}.
+
+get_db_subscribers(_LServer, _LBareJID) ->
+	{error, not_implemented}.
 
 store_room(_LServer, Host, Name, Opts) ->
     F = fun () ->

--- a/src/mod_muc_riak.erl
+++ b/src/mod_muc_riak.erl
@@ -36,7 +36,7 @@
 	 count_online_rooms_by_user/3, get_online_rooms_by_user/3]).
 -export([set_affiliation/6, set_affiliations/4, get_affiliation/5,
 	 get_affiliations/3, search_affiliation/4]).
--export([db_subscribe/2]).
+-export([db_subscribe/2, get_db_subscribers/2]).
 
 -include("jid.hrl").
 -include("mod_muc.hrl").
@@ -53,6 +53,9 @@ store_room(_LServer, Host, Name, Opts) ->
 			       muc_room_schema())}.
 
 db_subscribe(_JID, _Host) ->
+  {error, not_implemented}.
+
+get_db_subscribers(_LServer, _LBareJID) ->
   {error, not_implemented}.
 
 restore_room(_LServer, Host, Name) ->


### PR DESCRIPTION
Subscriptions are now persistent and no longer reliant on the muc room being in memory.  A bug was created as a side effect where all of the subscribed rooms that a user is subscribed to are brought back into memory, possibly due to a different SDK call.  This exacerbates the issue of too many muc rooms residing in memory.  Will file a separate bug to fix this.

Much like the other PR the mneisa and riak implementations are not going to be completed, as they will not be used.

Tested using multiple registered muc rooms, including 1x1 and 1x1x1.  

@RuoanJi 
@MattFoley 