### PR TITLE
[#160483755] bug message type offline message flow check

### DIFF
--- a/include/message_type.hrl
+++ b/include/message_type.hrl
@@ -15,3 +15,5 @@
          ?VsFriendsMessageType, 
          ?NudgeMessageType
         ]).
+
+-define(SdkElementsPosition, 3).

--- a/include/message_type.hrl
+++ b/include/message_type.hrl
@@ -1,6 +1,6 @@
 %%------------------------------------------------------------------------
 %%
-%% This file contains skillz message types that we shouldn't include in the 
+%% This file contains message types that we shouldn't include in the 
 %% offline message flow.
 %%
 %% Also contains various constant that we need to access these items.

--- a/include/message_type.hrl
+++ b/include/message_type.hrl
@@ -3,7 +3,7 @@
 %% This file contains message types that we shouldn't include in the 
 %% offline message flow.
 %%
-%% Also contains various constant that we need to access these items.
+%% Also contains various constant values that are the locations of stanza data.
 %%
 %%------------------------------------------------------------------------
 

--- a/include/message_type.hrl
+++ b/include/message_type.hrl
@@ -12,6 +12,6 @@
 
 -define(NoOfflineToSenderTypes, 
         [
-         [?VsFriendsMessageType], 
-         [?NudgeMessageType]
+         ?VsFriendsMessageType, 
+         ?NudgeMessageType
         ]).

--- a/include/skillz_message_type.hrl
+++ b/include/skillz_message_type.hrl
@@ -1,0 +1,17 @@
+%%------------------------------------------------------------------------
+%%
+%% This file contains skillz message types that we shouldn't include in the 
+%% offline message flow.
+%%
+%% Also contains various constant that we need to access these items.
+%%
+%%------------------------------------------------------------------------
+
+-define(VsFriendsMessageType, 1).
+-define(NudgeMessageType, 3).
+
+-define(NoOfflineToSenderTypes, 
+        [
+         [?VsFriendsMessageType], 
+         [?NudgeMessageType]
+        ]).

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4086,7 +4086,7 @@ inspect_sdk_xmlels(_, _, Acc) -> Acc.
 
 -spec should_send_message(stanza(), jid()) -> boolean().
 should_send_message(#message{sub_els = SubEls}, #jid{user = User}) ->
-    SdkEl = lists:nth(3, SubEls),
+    SdkEl = lists:nth(?SdkElementsPosition, SubEls),
     #xmlel{children = SdkChildren} = SdkEl,
     ShouldIgnore = lists:foldl(fun(Child, Acc) ->
         inspect_sdk_xmlels(User, Child, Acc)

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -55,7 +55,7 @@
 
 -include("mod_muc_room.hrl").
 
--include("skillz_message_type.hrl").
+-include("message_type.hrl").
 
 -define(MAX_USERS_DEFAULT_LIST,
 	[5, 10, 20, 30, 50, 100, 200, 500, 1000, 2000, 5000]).

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4073,25 +4073,14 @@ is_privacy_allow(Packet) ->
     LServer = To#jid.server,
     allow == ejabberd_hooks:run_fold(privacy_check_packet, LServer, allow, [To, Packet, in]).
 
--spec check_if_message_type(binary(), binary()) -> boolean().
-check_if_message_type(<<"message_type">>, CData) ->
-    lists:member(binary_to_integer(CData), ?NoOfflineToSenderTypes);
-check_if_message_type(_, _) -> false.
-
--spec check_if_user_id(binary(), binary(), binary()) -> boolean().
-check_if_user_id(<<"user_id">>, CData, User) when CData == User -> true;
-check_if_user_id(_, _, _) -> false.
-
 -spec inspect_sdk_xmlels(binary(), map(), list()) -> list().
 inspect_sdk_xmlels(User, #xmlel{name = Name, children = ChildrenList}, Acc) ->
     [Children|_] = ChildrenList,
     {_, CData} = Children,
-    MessageTypeCheck = check_if_message_type(Name, CData),
-    UserIdCheck = check_if_user_id(Name, CData, User),
-    if
-         MessageTypeCheck -> [true|Acc];
-         UserIdCheck -> [true|Acc];
-         true -> Acc
+    case Name of
+      <<"message_type">> -> [User == CData|Acc];
+      <<"user_id">> -> [lists:member(binary_to_integer(CData), ?NoOfflineToSenderTypes)|Acc];
+      _ -> Acc
     end;
 inspect_sdk_xmlels(_, _, Acc) -> Acc.
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4078,8 +4078,8 @@ inspect_sdk_xmlels(User, #xmlel{name = Name, children = ChildrenList}, Acc) ->
     [Children|_] = ChildrenList,
     {_, CData} = Children,
     case Name of
-      <<"message_type">> -> [User == CData|Acc];
-      <<"user_id">> -> [lists:member(binary_to_integer(CData), ?NoOfflineToSenderTypes)|Acc];
+      <<"user_id">> -> [User == CData|Acc];
+      <<"message_type">> -> [lists:member(binary_to_integer(CData), ?NoOfflineToSenderTypes)|Acc];
       _ -> Acc
     end;
 inspect_sdk_xmlels(_, _, Acc) -> Acc.

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4099,8 +4099,8 @@ inspect_sdk_xmlels(_, _, Acc) -> Acc.
 should_send_message(#message{sub_els = SubEls}, #jid{user = User}) ->
     SdkEl = lists:nth(3, SubEls),
     #xmlel{children = SdkChildren} = SdkEl,
-    ShouldIgnore = lists:foldl(fun(X, Acc) ->
-        inspect_sdk_xmlels(User, X, Acc)
+    ShouldIgnore = lists:foldl(fun(Child, Acc) ->
+        inspect_sdk_xmlels(User, Child, Acc)
     end, [], SdkChildren),
     ShouldIgnore /= [true, true].
 


### PR DESCRIPTION
If the message type is included in the list of message types then only send to the user(s) who didn't send the message.

@aghchan 
@kkaminski 