### PR TITLE
[#160483755] Fixing bad call to offline message

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4099,7 +4099,7 @@ should_send_message(#message{sub_els = SubEls}, #jid{user = User}) ->
 %% (Won't update offline message count).
 -spec send_to_room_or_offline(boolean(), boolean(), stanza(), binary()) -> any().
 send_to_room_or_offline(false, true, Packet, LServer) ->
-    ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, Packet});
+    ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, Packet}, []);
 send_to_room_or_offline(_, _, Packet, _) -> ejabberd_router:route(Packet).
 
 -spec send_wrapped(jid(), jid(), stanza(), binary(), state()) -> ok.


### PR DESCRIPTION
I did not include the third argument to this call.  See the messages going to the spool table now locally.

@aghchan 
@kkaminski 