### PR TITLE
[#162091837] Filtering messages before they go to push

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4099,7 +4099,8 @@ should_send_message(#message{sub_els = SubEls}, #jid{user = User}) ->
 %% (Won't update offline message count).
 -spec send_to_room_or_offline(boolean(), boolean(), stanza(), binary()) -> any().
 send_to_room_or_offline(false, true, Packet, LServer) ->
-    ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, Packet}, []);
+    NewPacket = ejabberd_hooks:run_fold(filter_packet, Packet, []),
+    ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, NewPacket}, []);
 send_to_room_or_offline(_, _, Packet, _) -> ejabberd_router:route(Packet).
 
 -spec send_wrapped(jid(), jid(), stanza(), binary(), state()) -> ok.


### PR DESCRIPTION
This should effectively call mod_pottymouth before sending the packet to mod_push_skillz.

Basically hitting a bloom filter, so it should be pretty performant. 

@aghchan 
@kkaminski  