### PR TITLE
[ES-950] Fixing muc memory leak found with send_stanza

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,5 @@
 
 ./autogen.sh
 ./configure --prefix=$HOME/my-ejabberd --enable-elixir --enable-odbc --enable-mysql --enable-tools
-make
+make ejabberd_debug=true
 make install

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1536,14 +1536,14 @@ build_packet(Type, Subject, Body) ->
 %% Taken from mod_muc_room 
 -spec wrap(jid(), jid(), stanza(), binary()) -> message().
 wrap(From, To, Packet, Node) ->
-	El = xmpp:encode(xmpp:set_from_to(Packet, From, To)),
-	#message{ 
-	   sub_els = [#ps_event{ 
-					 items = #ps_items{ 
-								node = Node, 
-								items = [#ps_item{ 
-											id = randoms:get_string(), 
-											xml_els = [El]}]}}]}.
+    El = xmpp:encode(xmpp:set_from_to(Packet, From, To)),
+    #message{
+       sub_els = [#ps_event{
+		     items = #ps_items{
+				node = Node,
+				items = [#ps_item{
+					    id = randoms:get_string(),
+					    xml_els = [El]}]}}]}.
 
 %% Note this doesn't filter what we are sending to it.  Don't pass along user generated
 %% messages :) (if you need to , fun the filter_packet hook!)

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1533,17 +1533,17 @@ build_packet(Type, Subject, Body) ->
 	     body = xmpp:mk_text(Body),
 	     subject = xmpp:mk_text(Subject)}.
 
-%% Stolen from mod_muc_room 
+%% Taken from mod_muc_room 
 -spec wrap(jid(), jid(), stanza(), binary()) -> message().
 wrap(From, To, Packet, Node) ->
-    El = xmpp:encode(xmpp:set_from_to(Packet, From, To)),
-    #message{
-       sub_els = [#ps_event{
-		     items = #ps_items{
-				node = Node,
-				items = [#ps_item{
-					    id = randoms:get_string(),
-					    xml_els = [El]}]}}]}.
+	El = xmpp:encode(xmpp:set_from_to(Packet, From, To)),
+	#message{ 
+	   sub_els = [#ps_event{ 
+					 items = #ps_items{ 
+								node = Node, 
+								items = [#ps_item{ 
+											id = randoms:get_string(), 
+											xml_els = [El]}]}}]}.
 
 %% Note this doesn't filter what we are sending to it.  Don't pass along user generated
 %% messages :) (if you need to , fun the filter_packet hook!)

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1533,13 +1533,30 @@ build_packet(Type, Subject, Body) ->
 	     body = xmpp:mk_text(Body),
 	     subject = xmpp:mk_text(Subject)}.
 
+%% Stolen from mod_muc_room 
+-spec wrap(jid(), jid(), stanza(), binary()) -> message().
+wrap(From, To, Packet, Node) ->
+    El = xmpp:encode(xmpp:set_from_to(Packet, From, To)),
+    #message{
+       sub_els = [#ps_event{
+		     items = #ps_items{
+				node = Node,
+				items = [#ps_item{
+					    id = randoms:get_string(),
+					    xml_els = [El]}]}}]}.
+
+%% Note this doesn't filter what we are sending to it.  Don't pass along user generated
+%% messages :) (if you need to , fun the filter_packet hook!)
 send_stanza(FromString, ToString, Stanza) ->
     try
 	#xmlel{} = El = fxml_stream:parse_element(Stanza),
-	From = jid:decode(FromString),
-	To = jid:decode(ToString),
-	Pkt = xmpp:decode(El, ?NS_CLIENT, [ignore_els]),
-	ejabberd_router:route(xmpp:set_from_to(Pkt, From, To))
+	From          = jid:decode(FromString),
+	To            = jid:decode(ToString),
+	LServer       = From#jid.lserver,
+	Packet        = xmpp:decode(El, ?NS_CLIENT, [ignore_els]),
+	Wrapped       = wrap(To, From, Packet, ?NS_MUCSUB_NODES_MESSAGES),
+	PacketToSend  = xmpp:set_from_to(Wrapped, To, From),
+	ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, [])
     catch _:{xmpp_codec, Why} ->
 	    io:format("incorrect stanza: ~s~n", [xmpp:format_error(Why)]),
 	    {error, Why};


### PR DESCRIPTION
### The Issue
Before send_stanza would shoot a message through the router, which spins up a muc room to direct the message to the offline message module.

## The Solution
Instead of sending it through the router, I copied the logic found where a message is sent to be stored.  Now we go directly to MySQL and bypass spinning up a new room.

Once again, this is a bandaid to the larger muc memory issue.

### Local Testing
Sending this stanza
```
./sbin/ejabberdctl send_stanza 5983820@chat.dev.skillz.com 5983817-5983820@conference.chat.dev.skillz.com "<message to='55983817-983820@chat.dev.skillz.com' from='5983820@conference.chat.dev.skillz.com/5983817' type='groupchat' id='1b5f966b-76d7-4617-b535-3d6c55dbf53b' xmlns='jabber:client'><skillz_sdk xmlns='xmpp:skillz'>       <avatar_url>https://cdn.qa.skillz.com/profile-pics/52319d0e-03fd-4786-8908-d134ce76f6d4</avatar_url>       <flag_url>https://cdn.qa.skillz.com/flags/US.png</flag_url>       <user_id>5983817</user_id>       <username>ejabberd3</username>       <user_role>3</user_role>       <user_mentions>@none</user_mentions>       <message_type>1</message_type>       <data>{&quot;matchCode&quot;:&quot;VSC31708&quot;,&quot;matchId&quot;:233302,&quot;iosSupport&quot;:true,&quot;androidApplicationId&quot;:&quot;com.skillz.android.shellgame.mercury&quot;,&quot;gameId&quot;:3382,&quot;gameName&quot;:&quot;Executive Only - DO NOT MODIFY&quot;,&quot;gameIconUrl&quot;:&quot;https://cdn.qa.skillz.com/devportal2/uploads/game/icon/1028/icon.png&quot;}</data>   </skillz_sdk><body>ejabberd3 has invited you to a tournament in Executive Only - DO NOT MODIFY</body></message>"
```

Shows up correctly formatted in my local database.

@Tdavis22 
@zgarbowitz 