### PR TITLE
[ES-950] Adjusting send_stanza flow to hit mod_mam

### DIFF
--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1566,7 +1566,7 @@ send_stanza(FromString, ToString, Stanza) ->
 	LServer       = From#jid.lserver,
 	Packet        = xmpp:decode(El, ?NS_CLIENT, [ignore_els]), 
 	ArchivePacket = ejabberd_hooks:run_fold(muc_filter_message, LServer, Packet, 
-											[spoof_muc_state(LServer, To), From#jid.user]),
+	                                        [spoof_muc_state(LServer, To), From#jid.user]),
 	Wrapped       = wrap(To, From, ArchivePacket, ?NS_MUCSUB_NODES_MESSAGES),
 	PacketToSend  = xmpp:set_from_to(Wrapped, To, From),
 	ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, [])


### PR DESCRIPTION
So I forgot a pathway.  In the `process_groupchat_message` in `src/mod_muc_room.erl` there is a call to `mod_mam` that archives the message, and appends two rows to the stanza before adding to the offline table (which then gets sent to ModPushSkillz).  ModPushSkillz was breaking because of this on QA.  SO, I'm adding that missing call.

I have to spoof being in a muc_room, because I didn't really see functionality that supports directly writing to mod_mam without being in a muc room.  I added a comment saying we should add it eventually, but it _probably_ won't break anytime soon, because we'd have bigger issues if we go changing our muc room settings so drastically.

I'll post example stanzaz from QA's offline message table and the ones I've now generated locally to show there isn't any disparity below.

@Tdavis22 
@zgarbowitz 