### PR TITLE
[ES-950] Offline messgaes sent to the correct user for send_stanza

### DIFF
--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1556,13 +1556,26 @@ spoof_muc_state(LServer, RoomJID) ->
 	   config = #config{
 			mam = true}}.
 
+get_offline_user(To, From) ->
+	FromUser = From#jid.user,
+	Room = To#jid.user,
+	Users = string:lexemes(Room, "-" ++ [[$\r,$\n]]),
+	[User1|User2] = Users,
+	NewUser = case User1 of
+		FromUser ->
+			hd(User2);
+		_ ->
+			User1
+	end,
+	From#jid{user = NewUser, luser = NewUser}.
+
 %% Note this doesn't filter what we are sending to it.  Don't pass along user generated
 %% messages :) (if you need to , fun the filter_packet hook!)
 send_stanza(FromString, ToString, Stanza) ->
     try
 	#xmlel{} = El = fxml_stream:parse_element(Stanza),
-	From          = jid:decode(FromString),
 	To            = jid:decode(ToString),
+	From          = get_offline_user(To, jid:decode(FromString)),
 	LServer       = From#jid.lserver,
 	Packet        = xmpp:decode(El, ?NS_CLIENT, [ignore_els]), 
 	ArchivePacket = ejabberd_hooks:run_fold(muc_filter_message, LServer, Packet, 

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1562,10 +1562,8 @@ get_offline_user(To, From) ->
 	Users = string:lexemes(Room, "-" ++ [[$\r,$\n]]),
 	[User1|User2] = Users,
 	NewUser = case User1 of
-		FromUser ->
-			hd(User2);
-		_ ->
-			User1
+		FromUser -> hd(User2);
+		_ -> User1
 	end,
 	From#jid{user = NewUser, luser = NewUser}.
 

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1557,13 +1557,13 @@ spoof_muc_state(LServer, RoomJID) ->
 			mam = true}}.
 
 get_offline_user(To, From) ->
-	FromUser = From#jid.user,
-	Room = To#jid.user,
-	Users = string:lexemes(Room, "-" ++ [[$\r,$\n]]),
+	FromUser      = From#jid.user,
+	Room          = To#jid.user,
+	Users         = string:lexemes(Room, "-" ++ [[$\r,$\n]]),
 	[User1|User2] = Users,
-	NewUser = case User1 of
+	NewUser       = case User1 of
 		FromUser -> hd(User2);
-		_ -> User1
+		_        -> User1
 	end,
 	From#jid{user = NewUser, luser = NewUser}.
 


### PR DESCRIPTION
OK, I forgot under the hood we actually don't send to the user we include, but to the opposite user.  I guess I could make a PR in the server-api repo instead of this one, but I don't know if that will break more stuff.  It looks like the correct user is inserted in the offline message table.

@Tdavis22 
@zgarbowitz 