### PR TITLE
[ES-1437] Kill mucs higher up in the call chain

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -156,8 +156,12 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, Opts, QueueType])
     add_to_log(room_existence, started, NewState),
     {ok, normal_state, NewState}.
 
+%% This is a top level call to normal_state to kill the muc room during any event.
+normal_state(Event, StateData) ->
+	{_, _, NewStateData} = normal_state(Event, StateData),
+	close_room_without_occupants(NewStateData);
 normal_state({route, <<"">>,
-	      #message{from = From, type = Type, lang = Lang} = Packet},
+              #message{from = From, type = Type, lang = Lang} = Packet},
 	     StateData) ->
     case is_user_online(From, StateData) orelse
 	is_subscriber(From, StateData) orelse
@@ -471,6 +475,9 @@ normal_state({route, ToNick,
 normal_state(_Event, StateData) ->
     {next_state, normal_state, StateData}.
 
+handle_event(Event, StateName, StateData) ->
+	{_, _, NewState} = handle_event(Event, StateName, StateData),
+	close_room_without_occupants(NewState);
 handle_event({service_message, Msg}, _StateName,
 	     StateData) ->
     MessagePkt = #message{type = groupchat, body = xmpp:mk_text(Msg)},

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -162,7 +162,7 @@ normal_state(Event, StateData) ->
 	{_, _, NewStateData} = normal_state(Event, StateData, true),
 	close_room_without_occupants(NewStateData).
 normal_state({route, <<"">>,
-	    #message{from = From, type = Type, lang = Lang} = Packet},
+	      #message{from = From, type = Type, lang = Lang} = Packet},
 	     StateData, _) ->
     case is_user_online(From, StateData) orelse
 	is_subscriber(From, StateData) orelse

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -162,7 +162,7 @@ normal_state(Event, StateData) ->
 	{_, _, NewStateData} = normal_state(Event, StateData, true),
 	close_room_without_occupants(NewStateData).
 normal_state({route, <<"">>,
-              #message{from = From, type = Type, lang = Lang} = Packet},
+	          #message{from = From, type = Type, lang = Lang} = Packet},
 	     StateData, _) ->
     case is_user_online(From, StateData) orelse
 	is_subscriber(From, StateData) orelse
@@ -476,9 +476,6 @@ normal_state({route, ToNick,
 normal_state(_Event, StateData, _) ->
     {next_state, normal_state, StateData}.
 
-handle_event(Event, StateName, StateData) ->
-	{_, _, NewState} = handle_event(Event, StateName, StateData),
-	close_room_without_occupants(NewState);
 handle_event({service_message, Msg}, _StateName,
 	     StateData) ->
     MessagePkt = #message{type = groupchat, body = xmpp:mk_text(Msg)},

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -157,12 +157,13 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, Opts, QueueType])
     {ok, normal_state, NewState}.
 
 %% This is a top level call to normal_state to kill the muc room during any event.
+%% Another hack we should remove once we have the process that sweeps empty mucs
 normal_state(Event, StateData) ->
-	{_, _, NewStateData} = normal_state(Event, StateData),
-	close_room_without_occupants(NewStateData);
+	{_, _, NewStateData} = normal_state(Event, StateData, true),
+	close_room_without_occupants(NewStateData).
 normal_state({route, <<"">>,
               #message{from = From, type = Type, lang = Lang} = Packet},
-	     StateData) ->
+	     StateData, _) ->
     case is_user_online(From, StateData) orelse
 	is_subscriber(From, StateData) orelse
 	is_user_allowed_message_nonparticipant(From, StateData) of
@@ -276,7 +277,7 @@ normal_state({route, <<"">>,
     end;
 normal_state({route, <<"">>,
 	      #iq{from = From, type = Type, lang = Lang, sub_els = [_]} = IQ0},
-	     StateData) when Type == get; Type == set ->
+	     StateData, _) when Type == get; Type == set ->
     try
 	case ejabberd_hooks:run_fold(
 	       muc_process_iq,
@@ -340,14 +341,14 @@ normal_state({route, <<"">>,
 	    Err = xmpp:err_bad_request(ErrTxt, Lang),
 	    ejabberd_router:route_error(IQ0, Err)
     end;
-normal_state({route, <<"">>, #iq{} = IQ}, StateData) ->
+normal_state({route, <<"">>, #iq{} = IQ}, StateData, _) ->
     Err = xmpp:err_bad_request(),
     ejabberd_router:route_error(IQ, Err),
     case StateData#state.just_created of
 	true -> {stop, normal, StateData};
 	false -> {next_state, normal_state, StateData}
     end;
-normal_state({route, Nick, #presence{from = From} = Packet}, StateData) ->
+normal_state({route, Nick, #presence{from = From} = Packet}, StateData, _) ->
     Activity = get_user_activity(From, StateData),
     Now = p1_time_compat:system_time(micro_seconds),
     MinPresenceInterval =
@@ -375,7 +376,7 @@ normal_state({route, Nick, #presence{from = From} = Packet}, StateData) ->
     end;
 normal_state({route, ToNick,
 	      #message{from = From, type = Type, lang = Lang} = Packet},
-	     StateData) ->
+	     StateData, _) ->
     case decide_fate_message(Packet, From, StateData) of
 	{expulse_sender, Reason} ->
 	    ?DEBUG(Reason, []),
@@ -441,7 +442,7 @@ normal_state({route, ToNick,
     end;
 normal_state({route, ToNick,
 	      #iq{from = From, id = StanzaId, lang = Lang} = Packet},
-	     StateData) ->
+	     StateData, _) ->
     case {(StateData#state.config)#config.allow_query_users,
 	  is_user_online_iq(StanzaId, From, StateData)} of
 	{true, {true, NewId, FromFull}} ->
@@ -472,7 +473,7 @@ normal_state({route, ToNick,
 	    ejabberd_router:route_error(Packet, Err)
     end,
     {next_state, normal_state, StateData};
-normal_state(_Event, StateData) ->
+normal_state(_Event, StateData, _) ->
     {next_state, normal_state, StateData}.
 
 handle_event(Event, StateName, StateData) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -162,7 +162,7 @@ normal_state(Event, StateData) ->
 	{_, _, NewStateData} = normal_state(Event, StateData, true),
 	close_room_without_occupants(NewStateData).
 normal_state({route, <<"">>,
-		      #message{from = From, type = Type, lang = Lang} = Packet},
+	    #message{from = From, type = Type, lang = Lang} = Packet},
 	     StateData, _) ->
     case is_user_online(From, StateData) orelse
 	is_subscriber(From, StateData) orelse

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -162,7 +162,7 @@ normal_state(Event, StateData) ->
 	{_, _, NewStateData} = normal_state(Event, StateData, true),
 	close_room_without_occupants(NewStateData).
 normal_state({route, <<"">>,
-	          #message{from = From, type = Type, lang = Lang} = Packet},
+		      #message{from = From, type = Type, lang = Lang} = Packet},
 	     StateData, _) ->
     case is_user_online(From, StateData) orelse
 	is_subscriber(From, StateData) orelse


### PR DESCRIPTION
Made a wrapper function that kills mucs higher up in the call chain.

Please note that I can't test this due to lack of local proxying, and there are 3 other functions where this issue can be happening.  If this issue persists, I can make another PR for the different functions.

This is because force closing the sdk re-opens rooms.

Left a note to remove this and add a module that cleans mucs periodically. 

@zgarbowitz 
@matlegit 