### PR TITLE
[ES-1307] Changing the change_room_option to persist changes

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3330,13 +3330,14 @@ set_config(Opts, Config, ServerHost, Lang) ->
 
 -spec change_config(#config{}, state()) -> {result, undefined, state()}.
 change_config(Config, StateData) ->
-    send_config_change_info(Config, StateData),
+    NewStateData = StateData#state{config = Config},
+    send_config_change_info(Config, NewStateData),
     case {(StateData#state.config)#config.persistent,
 	  Config#config.persistent}
 	of
       {_, true} ->
 	  mod_muc:store_room(StateData#state.server_host,
-			     StateData#state.host, StateData#state.room, make_opts(StateData));
+			     StateData#state.host, StateData#state.room, make_opts(NewStateData));
       {true, false} ->
 	  mod_muc:forget_room(StateData#state.server_host,
 			      StateData#state.host, StateData#state.room);
@@ -3346,8 +3347,8 @@ change_config(Config, StateData) ->
 	  Config#config.members_only}
 	of
       {false, true} ->
-	  NSD1 = remove_nonmembers(StateData), {result, undefined, NSD1};
-      _ -> {result, undefined, StateData}
+	  NSD1 = remove_nonmembers(NewStateData), {result, undefined, NSD1};
+      _ -> {result, undefined, NewStateData}
     end.
 
 -spec send_config_change_info(#config{}, state()) -> ok.


### PR DESCRIPTION
Basically the configs passed to this function are never saved to the DB.  I'm not sure why this is a noop currently?  But this seems to work.

NOTE: This doesn't _really_ work locally unless the debugger is running, but I see that some debug logging that I have removed are being printed when I hit the ejabberdctl.  So I think some code isn't being purged locally, very strange behavior.  I want to test this further on QA to see if I have an issue with my local setup.

Local testing:
```
./sbin/ejabberdctl create_room 11 conference.chat.dev.skillz.com chat.dev.skillz.com
./sbin/ejabberdctl change_room_option 11 conference.chat.dev.skillz.com title 'test1'
```
Then check the database, the title is changed.
Run this and see the title is changed:
```
./sbin/ejabberdctl get_room_options 11 conference.chat.dev.skillz.com
```

@Tdavis22 
@zgarbowitz 