### PR TITLE
[ES-1616] Fixing room creation issue and killing muc on all unavailable presences

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -969,8 +969,8 @@ process_presence(Nick, #presence{from = From, type = Type0} = Packet0, StateData
 	     drop ->
 		 {next_state, normal_state, StateData};
 	     #presence{} = Packet ->
-		 close_room_if_temporary_and_empty(
-		   close_room_without_occupants(Nick, Packet, StateData))
+		 close_room_without_occupants(
+		   do_process_presence(Nick, Packet, StateData))
 	   end;
        true ->
 		close_room_without_occupants(StateData)

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -156,14 +156,9 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, Opts, QueueType])
     add_to_log(room_existence, started, NewState),
     {ok, normal_state, NewState}.
 
-%% This is a top level call to normal_state to kill the muc room during any event.
-%% Another hack we should remove once we have the process that sweeps empty mucs
-normal_state(Event, StateData) ->
-	{_, _, NewStateData} = normal_state(Event, StateData, true),
-	close_room_without_occupants(NewStateData).
 normal_state({route, <<"">>,
 	      #message{from = From, type = Type, lang = Lang} = Packet},
-	     StateData, _) ->
+	     StateData) ->
     case is_user_online(From, StateData) orelse
 	is_subscriber(From, StateData) orelse
 	is_user_allowed_message_nonparticipant(From, StateData) of
@@ -277,7 +272,7 @@ normal_state({route, <<"">>,
     end;
 normal_state({route, <<"">>,
 	      #iq{from = From, type = Type, lang = Lang, sub_els = [_]} = IQ0},
-	     StateData, _) when Type == get; Type == set ->
+	     StateData) when Type == get; Type == set ->
     try
 	case ejabberd_hooks:run_fold(
 	       muc_process_iq,
@@ -341,14 +336,14 @@ normal_state({route, <<"">>,
 	    Err = xmpp:err_bad_request(ErrTxt, Lang),
 	    ejabberd_router:route_error(IQ0, Err)
     end;
-normal_state({route, <<"">>, #iq{} = IQ}, StateData, _) ->
+normal_state({route, <<"">>, #iq{} = IQ}, StateData) ->
     Err = xmpp:err_bad_request(),
     ejabberd_router:route_error(IQ, Err),
     case StateData#state.just_created of
 	true -> {stop, normal, StateData};
 	false -> {next_state, normal_state, StateData}
     end;
-normal_state({route, Nick, #presence{from = From} = Packet}, StateData, _) ->
+normal_state({route, Nick, #presence{from = From} = Packet}, StateData) ->
     Activity = get_user_activity(From, StateData),
     Now = p1_time_compat:system_time(micro_seconds),
     MinPresenceInterval =
@@ -376,7 +371,7 @@ normal_state({route, Nick, #presence{from = From} = Packet}, StateData, _) ->
     end;
 normal_state({route, ToNick,
 	      #message{from = From, type = Type, lang = Lang} = Packet},
-	     StateData, _) ->
+	     StateData) ->
     case decide_fate_message(Packet, From, StateData) of
 	{expulse_sender, Reason} ->
 	    ?DEBUG(Reason, []),
@@ -442,7 +437,7 @@ normal_state({route, ToNick,
     end;
 normal_state({route, ToNick,
 	      #iq{from = From, id = StanzaId, lang = Lang} = Packet},
-	     StateData, _) ->
+	     StateData) ->
     case {(StateData#state.config)#config.allow_query_users,
 	  is_user_online_iq(StanzaId, From, StateData)} of
 	{true, {true, NewId, FromFull}} ->
@@ -473,7 +468,7 @@ normal_state({route, ToNick,
 	    ejabberd_router:route_error(Packet, Err)
     end,
     {next_state, normal_state, StateData};
-normal_state(_Event, StateData, _) ->
+normal_state(_Event, StateData) ->
     {next_state, normal_state, StateData}.
 
 handle_event({service_message, Msg}, _StateName,
@@ -974,11 +969,11 @@ process_presence(Nick, #presence{from = From, type = Type0} = Packet0, StateData
 	     drop ->
 		 {next_state, normal_state, StateData};
 	     #presence{} = Packet ->
-		 close_room_without_occupants(
-		   do_process_presence(Nick, Packet, StateData))
+		 close_room_if_temporary_and_empty(
+		   close_room_without_occupants(Nick, Packet, StateData))
 	   end;
        true ->
-	    {next_state, normal_state, StateData}
+		close_room_without_occupants(StateData)
     end.
 
 -spec do_process_presence(binary(), presence(), state()) -> state().


### PR DESCRIPTION
### The issue
The top level function call that I added here: https://github.com/skillz/ejabberd/pull/79 was a bad idea.  We added it because I was having trouble with my local setup and couldn't actually connect.  What this did was create a 'race condition' of sorts appear _way_ more frequently.  It only happens 1% of the time on prod, going to file a different bug for that issue.

### Steps to solve
Connecting locally and setting break points, I see that the SDK is tearing down TCP connections differently(?).  This causes ejabberd to broadcast a message to all mucs that were connected to in the session once the SDK is force closed.  An unavailable presence is what is being broadcasted, but it wasn't hitting the previous logic added here: https://github.com/skillz/ejabberd/pull/78 , because the user is 'offline' at this point.

### The solution
Add a call to `close_rooms_without_occupants` at the section of code that isn't getting hit.

### Testing
Creating rooms works locally.  When leaving a room, it gets torn down.
When force closing the SDK, rooms aren't around long.
Can add friends and chat as working before.

### Problems with this fix
This fix causes all muc rooms a user has joined in a session to be temporarily brought back up.  We can prevent this by only calling that fix when the user force closes the SDK, but most users (probably?) leave the SDK open causing the rooms to still exist, instead of force closing it frequently.  SOOOO its the best of both worlds, and probably isn't really that bad anyways.

@Tdavis22 
@zgarbowitz 