### PR TITLE
[ES-1517] Bug online send stanza

### DIFF
--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1573,14 +1573,21 @@ send_stanza(FromString, ToString, Stanza) ->
     try
 	#xmlel{} = El = fxml_stream:parse_element(Stanza),
 	To            = jid:decode(ToString),
-	From          = get_offline_user(To, jid:decode(FromString)),
-	LServer       = From#jid.lserver,
-	Packet        = xmpp:decode(El, ?NS_CLIENT, [ignore_els]), 
-	ArchivePacket = ejabberd_hooks:run_fold(muc_filter_message, LServer, Packet, 
-	                                        [spoof_muc_state(LServer, To), From#jid.user]),
-	Wrapped       = wrap(To, From, ArchivePacket, ?NS_MUCSUB_NODES_MESSAGES),
-	PacketToSend  = xmpp:set_from_to(Wrapped, To, From),
-	ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, [])
+	case mod_muc:find_online_room(To#jid.user, To#jid.server) of
+	{ok, _} ->
+		From = jid:decode(FromString),
+		Pkt = xmpp:decode(El, ?NS_CLIENT, [ignore_els]),
+		ejabberd_router:route(xmpp:set_from_to(Pkt, From, To));
+	error ->
+		From          = get_offline_user(To, jid:decode(FromString)),
+		LServer       = From#jid.lserver,
+		Packet        = xmpp:decode(El, ?NS_CLIENT, [ignore_els]), 
+		ArchivePacket = ejabberd_hooks:run_fold(muc_filter_message, LServer, Packet, 
+												[spoof_muc_state(LServer, To), From#jid.user]),
+		Wrapped       = wrap(To, From, ArchivePacket, ?NS_MUCSUB_NODES_MESSAGES),
+		PacketToSend  = xmpp:set_from_to(Wrapped, To, From),
+		ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, [])
+	end
     catch _:{xmpp_codec, Why} ->
 	    io:format("incorrect stanza: ~s~n", [xmpp:format_error(Why)]),
 	    {error, Why};

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1583,7 +1583,7 @@ send_stanza(FromString, ToString, Stanza) ->
 		LServer       = From#jid.lserver,
 		Packet        = xmpp:decode(El, ?NS_CLIENT, [ignore_els]), 
 		ArchivePacket = ejabberd_hooks:run_fold(muc_filter_message, LServer, Packet, 
-												[spoof_muc_state(LServer, To), From#jid.user]),
+			                                    [spoof_muc_state(LServer, To), From#jid.user]),
 		Wrapped       = wrap(To, From, ArchivePacket, ?NS_MUCSUB_NODES_MESSAGES),
 		PacketToSend  = xmpp:set_from_to(Wrapped, To, From),
 		ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, [])


### PR DESCRIPTION
### The issue
When the send_stanza was called with the code we added to fix the memory leak, it didn't actually appear in an active process's room.  It would only show up in offline messages.

### The fix
Check if the room exists.  If it does, call the old code path.
This won't result in a process leak, as the new code path doesn't bring a room up, and the old code path is only active when someone is in a room.  When that person leaves then the room will be cleaned up.

### Local testing
Two devices connected locally.  Challenging someone shows a correctly rendered message in the room.

@Tdavis22 
@zgarbowitz 