### PR TITLE
[ES-1631] Fixing eimp in unupdated mix file

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -85,7 +85,7 @@ defmodule Ejabberd.Mixfile do
      {:distillery, "~> 2.0"},
      {:pkix, "~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev},
-     {:eimp, "~> 1.0"},
+     {:eimp, "~> 1.0.10"},
      {:base64url, "~> 0.0.1"},
      {:jose, "~> 1.8"}]
     ++ cond_deps()


### PR DESCRIPTION
So I am seeing these in the logs in QA after the `19.02` upgrade:
```erlang
2019-03-13 20:43:34.906 [error] <0.202.0> got unexpected info: {'EXIT',#Port<0.2518>,noproc}
2019-03-13 20:43:35.310 [error] <0.202.0> got unexpected info: {'EXIT',#Port<0.2519>,noproc}
2019-03-13 20:43:36.065 [error] <0.202.0> got unexpected info: {'EXIT',#Port<0.2520>,noproc}
2019-03-13 20:43:36.497 [error] <0.202.0> got unexpected info: {'EXIT',#Port<0.2521>,noproc}
2019-03-13 20:43:36.853 [error] <0.202.0> got unexpected info: {'EXIT',#Port<0.2522>,noproc}
2019-03-13 20:43:37.679 [error] <0.202.0> got unexpected info: {'EXIT',#Port<0.2523>,noproc}
2019-03-13 20:43:37.742 [error] <0.202.0> got unexpected info: {'EXIT',#Port<0.2524>,noproc}
2019-03-13 20:43:38.061 [error] <0.202.0> External eimp process (pid=7054) has terminated unexpectedly, restarting in a few seconds
```

After reading through [this](https://github.com/processone/ejabberd/commit/0f86559d83a37d97e1ce18aa346a67f7d0b391e2) PR to ejabberd, it looks like they updated the `rebar.config` file, and didn't upgrade the `mix.exs` file, which is what we use to fetch the deps.  So I'm gonna bump this up to the latest version.

Note, didn't see this locally.  Not sure why its happening on QA.  Maybe library differences between OSX and Ubuntu?

@Tdavis22 
@zgarbowitz 