### PR TITLE
[ES-1631] Transform subscription table

### DIFF
--- a/sql/2019-03-13-transform-subscription-table.sql
+++ b/sql/2019-03-13-transform-subscription-table.sql
@@ -10,9 +10,10 @@ SELECT
     SUBSTRING_INDEX(room, '@', 1),
     SUBSTRING_INDEX(room, '@', -1),
     jid,
+    SUBSTRING_INDEX(jid, '@', 1),
     '[<<"urn:xmpp:mucsub:nodes:messages">>,
-      <<"urn:xmpp:mucsub:nodes:affiliations">>,<<"urn:xmpp:mucsub:nodes:subject">>,
-      <<"urn:xmpp:mucsub:nodes:config">>]',
+  <<"urn:xmpp:mucsub:nodes:affiliations">>,<<"urn:xmpp:mucsub:nodes:subject">>,
+  <<"urn:xmpp:mucsub:nodes:config">>]',
     created_at
 FROM 
     subscription;

--- a/sql/2019-03-13-transform-subscription-table.sql
+++ b/sql/2019-03-13-transform-subscription-table.sql
@@ -1,0 +1,22 @@
+/**
+  * This is a SQL migration to move data from the subscription table to the muc_room_subscribers table.
+  *
+  **/
+
+/* Copy data. */
+INSERT INTO 
+    muc_room_subscribers (room, host, jid, nick, nodes, created_at)
+SELECT 
+    SUBSTRING_INDEX(room, '@', 1),
+    SUBSTRING_INDEX(room, '@', -1),
+    jid,
+    '[<<"urn:xmpp:mucsub:nodes:messages">>,
+      <<"urn:xmpp:mucsub:nodes:affiliations">>,<<"urn:xmpp:mucsub:nodes:subject">>,
+      <<"urn:xmpp:mucsub:nodes:config">>]',
+    created_at
+FROM 
+    subscription;
+
+/* Clear table of results. */
+TRUNCATE TABLE subscription;
+DROP     TABLE subscription;

--- a/sql/2019-03-13-transform-subscription-table.sql
+++ b/sql/2019-03-13-transform-subscription-table.sql
@@ -17,7 +17,3 @@ SELECT
     created_at
 FROM 
     subscription;
-
-/* Clear table of results. */
-TRUNCATE TABLE subscription;
-DROP     TABLE subscription;


### PR DESCRIPTION
It looks like the work to actually use the `muc_room_subscription` table has been more or less done.  So this sql is to move all of our records from the `subscription` table to the `muc_room_subscription` table.

That string is a constant value that is provided.  Several steps of string processing is done during this query.  The table will not have data being written to it while we're draining it.

@Tdavis22 
@zgarbowitz 