### PR TITLE
[ES-1694] Adjusting the subscription migration to deal with overlap

### DIFF
--- a/sql/2019-03-13-transform-subscription-table.sql
+++ b/sql/2019-03-13-transform-subscription-table.sql
@@ -4,9 +4,9 @@
   **/
 
 /* Copy data. */
-INSERT INTO 
+INSERT INTO
     muc_room_subscribers (room, host, jid, nick, nodes, created_at)
-SELECT 
+SELECT
     SUBSTRING_INDEX(room, '@', 1),
     SUBSTRING_INDEX(room, '@', -1),
     jid,
@@ -15,5 +15,11 @@ SELECT
   <<"urn:xmpp:mucsub:nodes:affiliations">>,<<"urn:xmpp:mucsub:nodes:subject">>,
   <<"urn:xmpp:mucsub:nodes:config">>]',
     created_at
-FROM 
-    subscription;
+FROM
+    subscription
+ON DUPLICATE KEY UPDATE
+	nodes =
+'[<<"urn:xmpp:mucsub:nodes:messages">>,
+  <<"urn:xmpp:mucsub:nodes:affiliations">>,<<"urn:xmpp:mucsub:nodes:subject">>,
+  <<"urn:xmpp:mucsub:nodes:config">>]';
+


### PR DESCRIPTION
Realized the old migration didn't deal with duplicates, and there is a unique index on one of the columns.  So if there is overlap then this would error out and won't run.

EDIT: What this does is noop on duplicate keys by inserting the constant value.  Using Insert Ignore causes all errors to be treated as warnings (is what I believe I read last week), and we would still want this to error in any other case.

@Tdavis22 
@zgarbowitz 