### PR TITLE
[ES-1890] Re-adding previously removed memory leak fix

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4104,7 +4104,11 @@ process_iq_mucsub(From, #iq{type = get, lang = Lang,
 		     fun(_, #subscriber{jid = J, nodes = Nodes}, Acc) ->
 			     [#muc_subscription{jid = J, events = Nodes}|Acc]
 		     end, [], StateData#state.subscribers),
-	    {result, #muc_subscriptions{list = Subs}, StateData};
+        NewStateData = case close_room_without_occupants(StateData) of
+            {stop, normal, _} -> stop;
+            {next_state, normal_state, SD} -> SD
+        end,
+	    {result, #muc_subscriptions{list = Subs}, NewStateData};
        true ->
 	    Txt = <<"Moderator privileges required">>,
 	    {error, xmpp:err_forbidden(Txt, Lang)}

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4104,10 +4104,10 @@ process_iq_mucsub(From, #iq{type = get, lang = Lang,
 		     fun(_, #subscriber{jid = J, nodes = Nodes}, Acc) ->
 			     [#muc_subscription{jid = J, events = Nodes}|Acc]
 		     end, [], StateData#state.subscribers),
-        NewStateData = case close_room_without_occupants(StateData) of
-            {stop, normal, _} -> stop;
-            {next_state, normal_state, SD} -> SD
-        end,
+	    NewStateData = case close_room_without_occupants(StateData) of
+	        {stop, normal, _} -> stop;
+	        {next_state, normal_state, SD} -> SD
+	    end,
 	    {result, #muc_subscriptions{list = Subs}, NewStateData};
        true ->
 	    Txt = <<"Moderator privileges required">>,


### PR DESCRIPTION
## The Issue
Chat is now OTA.  I guess Cobalt Plus and below it isn't.  So games on those SDKs have the old code that has issues which hit this code branch last.

Seeing this in QA
```bash
[ejabberd@islay-ejabberd-i-0ca5c2447e09098bc ~]$ ./sbin/ejabberdctl muc_online_rooms global
1688@conference.chat.qa.skillz.com
[ejabberd@islay-ejabberd-i-0ca5c2447e09098bc ~]$ ./sbin/ejabberdctl muc_online_rooms global
1688@conference.chat.qa.skillz.com
5974475-5983801@conference.chat.qa.skillz.com
5978567-5983801@conference.chat.qa.skillz.com
5983800-5983801@conference.chat.qa.skillz.com
5983801-5983808@conference.chat.qa.skillz.com
5983801-5983820@conference.chat.qa.skillz.com
5983801-5998750@conference.chat.qa.skillz.com
```
Basically the moment you join a room, every room you have becomes active.  Force closing the app has no effect, as those SDK changes aren't available either.

## The solution
Re-add the code.  Based off of this PR https://github.com/skillz/ejabberd/pull/78

### Note
I can't test this locally.  Zinc and beyond have the code for the SOCKS chat proxy.  Cobalt Plus does not.  So I hope this is enough to fix the issue still.

@Tdavis22 
@zgarbowitz 