### PR TITLE
[ES-1950] Changing send_stanza's return value

### DIFF
--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1531,7 +1531,7 @@ send_stanza(FromString, ToString, Stanza) ->
 		Wrapped       = wrap(To, From, ArchivePacket, ?NS_MUCSUB_NODES_MESSAGES),
 		PacketToSend  = xmpp:set_from_to(Wrapped, To, From),
 		ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, []),
-        ok
+		ok
 	end
     catch _:{xmpp_codec, Why} ->
 	    io:format("incorrect stanza: ~s~n", [xmpp:format_error(Why)]),

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1530,7 +1530,8 @@ send_stanza(FromString, ToString, Stanza) ->
 			                                    [spoof_muc_state(LServer, To), From#jid.user]),
 		Wrapped       = wrap(To, From, ArchivePacket, ?NS_MUCSUB_NODES_MESSAGES),
 		PacketToSend  = xmpp:set_from_to(Wrapped, To, From),
-		ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, [])
+		ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, []),
+        ok
 	end
     catch _:{xmpp_codec, Why} ->
 	    io:format("incorrect stanza: ~s~n", [xmpp:format_error(Why)]),


### PR DESCRIPTION
## The Issue
The http api `send_stanza` endpoint consistently returns 1 instead of 0.

## The Change
If you look at the code, there are two paths that can be taken, one ends with:
`ejabberd_router:route(xmpp:set_from_to(Packet, From, To))`
and the other ends with
`ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, [])`

These two functions have different return values.  The first code path is pre-memory leak fix.  Its return value is this:
`-spec route(stanza()) -> ok`

While the new code path's return value is this:
`-spec run_fold(atom(), any(), list()) -> any().`

## The Fix
Have send stanza return `ok`.

## Diagnoses
I saw a 'failed' nudge in game play and reproduced it using this command:
```
./sbin/ejabberdctl send_stanza 21951872@chat.qa.skillz.com 21579669-21951872@conference.chat.qa.skillz.com "<message   xmlns='jabber:client' from='21951872@chat.qa.skillz.com' to='21579669-21951872@conference.chat.qa.skillz.com' id='45226f1b-980c-430d-8384-17462b0240de' type='groupchat'>   <body>Chouime9 has invited you to a tournament in Spider Solitaire Cube</body>   <skillz_sdk        xmlns='xmpp:skillz'>       <avatar_url>default-profile-pics/Guy1_005.png</avatar_url>       <flag_url>https://cdn.skillz.com/flags/CA.png</flag_url>       <user_id>21951872</user_id>       <username>Chouime9</username>       <user_role>3</user_role>       <user_mentions>@none</user_mentions>       <message_type>3</message_type>       <data>{\"matchCode\":\"VSA894BD\",\"matchId\":748450411,\"iosSupport\":true,\"androidApplicationId\":null,\"gameId\":1853,\"gameName\":\"Spider Solitaire Cube\",\"gameIconUrl\":\"https://cdn.skillz.com/devportal2/uploads/game/icon/1820/appicon-1024-spider-a2.png\",\"recipientPlayerName\":\"GymJen\"}</data>   </skillz_sdk></message>"
```

Which returned without error.  This means no bad pattern matching or bad routing, etc could be happening.  It must be the interactions between the `mod_admin_extra` and the `mod_http_api` modules.  Which would be looking at the return values from `send_stanza`

## Local Testing
I checkout the release that prod is on.  I curled the endpoint after building using this:
```
curl -X POST localhost:5290/api/send_stanza --data-binary "
{"from": "21951872@chat.dev.skillz.com", "to": "21579669-21951872@conference.chat.dev.skillz.com", "stanza": "<message   xmlns='jabber:client' from='21951872@chat.qa.skillz.com' to='21579669-21951872@conference.chat.qa.skillz.com' id='45226f1b-980c-430d-8384-17462b0240de' type='groupchat'>   <body>Chouime9 has invited you to a tournament in Spider Solitaire Cube</body>   <skillz_sdk        xmlns='xmpp:skillz'>       <avatar_url>default-profile-pics/Guy1_005.png</avatar_url>       <flag_url>https://cdn.skillz.com/flags/CA.png</flag_url>       <user_id>21951872</user_id>       <username>Chouime9</username>       <user_role>3</user_role>       <user_mentions>@none</user_mentions>       <message_type>3</message_type>       <data>{\"matchCode\":\"VSA894BD\",\"matchId\":748450411,\"iosSupport\":true,\"androidApplicationId\":null,\"gameId\":1853,\"gameName\":\"Spider Solitaire Cube\",\"gameIconUrl\":\"https://cdn.skillz.com/devportal2/uploads/game/icon/1820/appicon-1024-spider-a2.png\",\"recipientPlayerName\":\"GymJen\"}</data>   </skillz_sdk></message>"}
"
```

And 1 was returned.

Cleaning the build, checking out this branch, and recurling returns a 0.

@hacctarr 
@Tdavis22 
@zgarbowitz 
