### PR TITLE
[ES-2054] Fixing roster_out_subscription call

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -656,7 +656,7 @@ route_probe_reply(_, _) ->
     ok.
 
 -spec process_presence_out(state(), presence()) -> state().
-process_presence_out(#{lserver := LServer, jid := JID,
+process_presence_out(#{user := User, server := Server, lserver := LServer, jid := JID,
 		       lang := Lang, pres_a := PresA} = State,
 		     #presence{from = From, to = To, type = Type} = Pres) ->
     if Type == subscribe; Type == subscribed;
@@ -672,7 +672,7 @@ process_presence_out(#{lserver := LServer, jid := JID,
 		    case is_privacy_allow(Pres, To) of
 			true ->
 			    ?DEBUG("Packet was allowed due to privacy list for roster out sub: ~p and To ~p", [Pres, To]),
-			    ejabberd_hooks:run(roster_out_subscription, LServer, [User, Server, To Type]);
+			    ejabberd_hooks:run(roster_out_subscription, LServer, [User, Server, To, Type]);
 			false ->
 			    ?DEBUG("Packet wasnt allowed due to privacy list for roster out sub: ~p", [Pres])
 		    end

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -672,7 +672,7 @@ process_presence_out(#{lserver := LServer, jid := JID,
 		    case is_privacy_allow(Pres, To) of
 			true ->
 			    ?DEBUG("Packet was allowed due to privacy list for roster out sub: ~p and To ~p", [Pres, To]),
-			    ejabberd_hooks:run(roster_out_subscription, LServer, [Pres]);
+			    ejabberd_hooks:run(roster_out_subscription, LServer, [User, Server, To Type]);
 			false ->
 			    ?DEBUG("Packet wasnt allowed due to privacy list for roster out sub: ~p", [Pres])
 		    end


### PR DESCRIPTION
## The Issue
Pushes aren't being sent.

## Logs:
```
2019-04-07 23:07:02.732 [error] <0.19456.153>@ejabberd_hooks:safe_apply:384 Hook roster_out_subscription crashed when running 'Elixir.ModPushSkillz':on_roster_out_subscription/1:     

                                                    
** Reason = {error,undef,[{'Elixir.ModPushSkillz',on_roster_out_subscription,[{presence,<<"2dd2daa1-f596-414f-81db-2a64fbcb210d">>,subscribe,<<"en">>,{jid,<<"24788539">>,<<"chat.skillz.com">>,<<"498539436786344146026476322">>,<<"24788539">>,<<"chat.skillz.com">>,<<"498539436786344146026476322">>},{jid,<<"24083080">>,<<"chat.skillz.com">>,<<>>,<<"24083080">>,<<"chat.skillz.com">>,<<>>},undefined,[],undefined,[{xmlel,<<"player">>,[{<<"xmlns">>,<<"skillz:presence">>}],[]}],#{ip => {172,16,3,27}}}],[]},{ejabberd_hooks,safe_apply,4,[{file,"src/ejabberd_hooks.erl"},{line,381}]},{ejabberd_hooks,run1,3,[{file,"src/ejabberd_hooks.erl"},{line,330}]},{ejabberd_c2s,process_presence_out,2,[{file,"src/ejabberd_c2s.erl"},{line,675}]},{xmpp_stream_in,process_authenticated_packet,2,[{file,"src/xmpp_stream_in.erl"},{line,656}]},{xmpp_stream_in,handle_info,2,[{file,"src/xmpp_stream_in.erl"},{line,353}]},{p1_server,handle_msg,8,[{file,"src/p1_server.erl"},{line,696}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}
```

Looks like `on_roster_out_subscription` isn't playing happy.

## The Fix
`mod_push_skillz` takes 4 arguments, see here:
https://github.com/skillz/mod_push_skillz/blob/master/lib/mod_push_skillz.ex#L43

This commit from ejabberd main changed the call to `on_roster_out_subscription` to use 1 argument only.
https://github.com/processone/ejabberd/commit/4b012a99d2bdd6d22f05676e9a7989409e314fca#diff-4da3143d0c53219913b816c23d48feb7L661

I am attempting to change this back to 4 arguments and see if this makes a difference.  Can't really test this locally.

@dawsonz17 
@zgarbowitz 
@hacctarr 