### PR TITLE
[ES-2054] Reverting wrap function in mod_muc_room

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4511,7 +4511,7 @@ send_wrapped(From, To, Packet, Node, State) ->
 
 -spec wrap(jid(), jid(), stanza(), binary()) -> message().
 wrap(From, To, Packet, Node) ->
-    El = xmpp:set_from_to(Packet, From, To),
+    El = xmpp:encode(xmpp:set_from_to(Packet, From, To)),
     #message{
        sub_els = [#ps_event{
 		     items = #ps_items{


### PR DESCRIPTION
Okay, so I see this line was changed in the latest version of ejabberd.  I saw here: https://github.com/skillz/ejabberd/blob/development/src/mod_admin_extra.erl#L1483 that we had it as a different function call before.  The code linked is supposed to emulate this code, but this code has changed.  This is why nudges work, but chat DMs don't.  

I can't test pushes locally, but I am able to reproduce the errors on QA/Staging/Production on my local setup.  With this new code I don't see the errors locally.

I'm going to use QA to test actual pushing functionality.

Asked processone if this was cool to do here, but I'm sure its okay
https://support.process-one.net/browse/EJABS-3299

@dawsonz17 
@zgarbowitz 