### PR TITLE
[ES-2097] Fixing newer kick_session endpoint

### DIFF
--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -898,11 +898,17 @@ ban_account(User, Host, ReasonText) ->
     ok.
 
 kick_sessions(User, Server, Reason) ->
-    lists:map(
+    Results = lists:map(
       fun(Resource) ->
 	      kick_this_session(User, Server, Resource, Reason)
       end,
-      ejabberd_sm:get_user_resources(User, Server)).
+      ejabberd_sm:get_user_resources(User, Server)),
+
+    FilteredResults = lists:filter(fun(X) -> X /= ok end, Results),
+    case FilteredResults of
+        [] -> ok;
+        _ -> error
+    end.
 
 set_random_password(User, Server, Reason) ->
     NewPass = build_random_password(Reason),


### PR DESCRIPTION
## The Issue
When trying to mute a user, an error is being returned to the SDK.

Previously ejabberd was using the `kick_session` function call for this.  NOW it uses `kick_sessions` function call.

The `kick_sessions` function has a bug when interacting with the http api module.  The module expects functions to return `ok`, but `kick_sessions` returns a list of return values as it now scans over every possible session for a user.  So it'd return a `[ok, ok, ok]` if there were 3 sessions that were successfully terminated.

## The Fix
What the fix actually does is loop over the returned list, and filter out all `ok` values.  If any values remain, that means `kick_sessions` has an error and not all sessions have been kicked.  If the list is empty, then we return `ok`, as thats what http api module is expecting.

Curling locally before the fix returned a `1`.  user-details-service compares the return value to `0`, so thats why wer return an error to the sdk.  

Now this curl
```
curl localhost:5290/api/kick_session -X POST -d 
'{"user":"9", "host": "chat.dev.skillz.com", "reason": "asdfasdf"}'
```

Returns a `0`, and all should be good.

@dawsonz17 @hacctarr @zgarbowitz 