### PR TITLE
[ES-2223] Fixing change config (for CT tests)

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3492,9 +3492,8 @@ set_config(Opts, Config, ServerHost, Lang) ->
 
 -spec change_config(#config{}, state()) -> {result, undefined, state()}.
 change_config(Config, StateData) ->
-    StateData0 = StateData#state{config = Config},
-    send_config_change_info(Config, StateData0),
-    StateData1 = remove_subscriptions(StateData0),
+    send_config_change_info(Config, StateData),
+    StateData1 = StateData#state{config = Config},
     StateData2 =
         case {(StateData#state.config)#config.persistent,
               Config#config.persistent} of


### PR DESCRIPTION
I believe this code got mangled during the upgrade.

Previous results: `416 Ok, 171 Failed, 853 Skipped of 1440` in `1303.445s`

After this PR: `500 Ok, 100 Failed, 840 Skipped of 1440` in `407.516s`!!!!

83 more tests in like half the time 😃 

@dawsonz17 
@zgarbowitz 
@hacctarr 