### PR TITLE
[ES-2224] Fixing more ct tests around ownership issues

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,8 @@ defmodule Ejabberd.Mixfile do
      {:pkix, "~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev},
      {:base64url, "~> 0.0.1"},
-     {:jose, "~> 1.8"}]
+     {:jose, "~> 1.8"},
+     {:meck, "0.8.13", only: :test}]
     ++ cond_deps()
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -21,6 +21,7 @@
   "luerl": {:hex, :luerl, "0.3.1", "5412807630aac1aaf59ffe5a1bc09259c447b4faeb1d3fe2d4ef41b87676cb04", [:rebar3], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
   "mqtree": {:hex, :mqtree, "1.0.2", "8c41098424b13c67bddb71c966aa19ae72209d8b8f066d0ac9157d5c2834b68b", [:rebar3], [{:p1_utils, "1.0.14", [hex: :p1_utils, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "p1_mysql": {:hex, :p1_mysql, "1.0.9", "43ca869d3797b0248630cac0e05042e5e1b77d5cc3164206b10079c8d9182e0e", [:rebar3], [], "hexpm"},

--- a/rebar.config
+++ b/rebar.config
@@ -55,6 +55,8 @@
                                                {git, "https://github.com/processone/rebar_elixir_plugin", "0.1.0"}}}},
         {if_var_true, tools, {luerl, ".*", {git, "https://github.com/rvirding/luerl",
                                             {tag, "v0.3"}}}},
+       {if_var_true, tools,
+                    {meck, ".*", {git, "https://github.com/eproxus/meck", {tag, "0.8.13"}}}},
         {if_var_true, redis, {eredis, ".*", {git, "https://github.com/wooga/eredis",
                                              {tag, "v1.0.8"}}}}]}.
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3997,9 +3997,9 @@ process_iq_vcard(_From, #iq{type = get}, StateData) ->
 	    {error, xmpp:err_item_not_found()}
     end;
 process_iq_vcard(From, #iq{type = set, lang = Lang, sub_els = [Pkt]},
-		 StateData) ->
-    case get_affiliation(From, StateData) of
-	Affiliation when Affiliation == owner, Affiliation == admin ->
+		 StateData) -> 
+	case get_affiliation(From, StateData) of 
+	owner ->
 	    SubEl = xmpp:encode(Pkt),
 	    VCardRaw = fxml:element_to_binary(SubEl),
 	    Hash = mod_vcard_xupdate:compute_hash(SubEl),


### PR DESCRIPTION
Adding `meck` back for future tests.

Status is now:
`532 Ok, 68 Failed, 840 Skipped of 1440` in `324.374s`.

32 more tests passing.

This change was intentionally made.  Will do some local testing to confirm if this is actually what we want.