### PR TITLE
[ES-2257] SQL to remove bad friends requests during previous bug

### DIFF
--- a/sql/2019-05-02-remove-outbound-friend-requests.sql
+++ b/sql/2019-05-02-remove-outbound-friend-requests.sql
@@ -1,0 +1,12 @@
+/**
+  * This is a SQL migration to remove friends requests that can't be completed from when we had the active
+  * P0 bug: ES-2123, post upgrade.
+  *
+  **/
+
+DELETE FROM
+    rosterusers
+WHERE
+    ask != "N"
+    AND subscription != "B"
+    AND (created_at BETWEEN "2019-04-08 00:00:00" AND "2019-04-24 00:00:00");


### PR DESCRIPTION
During this P0: https://skillzinc.atlassian.net/browse/ES-2123 friends requests couldn't go through to users.  The following SQL clears this bad data and friends requests during the time of the bug being reported and resolved will be cleared out.

Ran successfully of staging and QA and two accounts who had outstanding friends requests that couldn't be accepted were able to re-send the requests and actually complete the friend request process.

@hacctarr 
@zgarbowitz 
@dawsonz17 