### PR TITLE
[ES-2221] Updating mix for umbrella child

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@
 /doc/*.toc
 /doc/contributed_modules.tex
 /doc/version.tex
-/ebin/
 /ejabberd.init
 /ejabberd.service
 /ejabberdctl.example

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 /doc/*.toc
 /doc/contributed_modules.tex
 /doc/version.tex
+/ebin/
 /ejabberd.init
 /ejabberd.service
 /ejabberdctl.example

--- a/lib/mix/tasks/ct.ex
+++ b/lib/mix/tasks/ct.ex
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Ct do
     {:ok, hostname} = :inet.gethostname
     default_label   = "ct_test_run_#{datetime_string}_#{hostname}"
 
-    cwd       = File.cwd!
+    cwd       = "#{File.cwd!}/apps/ejabberd"
     dir       = Keyword.get(options, :dir, "#{cwd}/test")                       |> String.to_charlist
     logdir    = Keyword.get(options, :logdir, "#{cwd}/logs")                    |> String.to_charlist
     suite     = Keyword.get(options, :suite, "#{cwd}/test/ejabberd_SUITE.erl")  |> String.to_charlist

--- a/lib/mix/tasks/ct.ex
+++ b/lib/mix/tasks/ct.ex
@@ -38,9 +38,9 @@ defmodule Mix.Tasks.Ct do
   @default_includes [
     "include/",
     "tools",
-    "deps/p1_utils/include",
-    "deps/fast_xml/include",
-    "deps/xmpp/include"
+    "../../deps/p1_utils/include",
+    "../../deps/fast_xml/include",
+    "../../deps/xmpp/include"
   ]
 
   def run(args) do

--- a/lib/mix/tasks/ct.ex
+++ b/lib/mix/tasks/ct.ex
@@ -66,15 +66,18 @@ defmodule Mix.Tasks.Ct do
     cwd       = File.cwd!
     child_cwd = "#{cwd}/apps/ejabberd" # TODO: kind of a hack.  this should be fixed forsure.
     dir       = Keyword.get(options, :dir, "#{child_cwd}/test")                       |> String.to_charlist
-    logdir    = Keyword.get(options, :logdir, "#{cwd}/logs")                    |> String.to_charlist
+    logdir    = Keyword.get(options, :logdir, "#{cwd}/logs")                          |> String.to_charlist
     suite     = Keyword.get(options, :suite, "#{child_cwd}/test/ejabberd_SUITE.erl")  |> String.to_charlist
-    ct_hooks  = Keyword.get(options, :ct_hooks, "cth_surefire")                 |> String.to_atom
+    ct_hooks  = Keyword.get(options, :ct_hooks, "cth_surefire")                       |> String.to_atom
     cover     = Keyword.get(options, :cover, "#{child_cwd}/cover.spec")               |> String.to_charlist
-    label     = Keyword.get(options, :name, default_label)                      |> String.to_charlist
-    include   = Keyword.get(options, :include, @default_includes |> Enum.join(","))
+    label     = Keyword.get(options, :name, default_label)                            |> String.to_charlist
+    include   = Keyword.get(options, :include, @default_includes                      |> Enum.join(","))
 
     # Create the logdir.
     File.mkdir(logdir)
+
+    # Create required ebin directory to placate ct.
+    File.mkdir("#{child_cwd}/ebin")
 
     # Convert all includes to charlists
     chars_include = 

--- a/lib/mix/tasks/ct.ex
+++ b/lib/mix/tasks/ct.ex
@@ -63,12 +63,13 @@ defmodule Mix.Tasks.Ct do
     {:ok, hostname} = :inet.gethostname
     default_label   = "ct_test_run_#{datetime_string}_#{hostname}"
 
-    cwd       = "#{File.cwd!}/apps/ejabberd"
-    dir       = Keyword.get(options, :dir, "#{cwd}/test")                       |> String.to_charlist
+    cwd       = File.cwd!
+    child_cwd = "#{cwd}/apps/ejabberd" # TODO: kind of a hack.  this should be fixed forsure.
+    dir       = Keyword.get(options, :dir, "#{child_cwd}/test")                       |> String.to_charlist
     logdir    = Keyword.get(options, :logdir, "#{cwd}/logs")                    |> String.to_charlist
-    suite     = Keyword.get(options, :suite, "#{cwd}/test/ejabberd_SUITE.erl")  |> String.to_charlist
+    suite     = Keyword.get(options, :suite, "#{child_cwd}/test/ejabberd_SUITE.erl")  |> String.to_charlist
     ct_hooks  = Keyword.get(options, :ct_hooks, "cth_surefire")                 |> String.to_atom
-    cover     = Keyword.get(options, :cover, "#{cwd}/cover.spec")               |> String.to_charlist
+    cover     = Keyword.get(options, :cover, "#{child_cwd}/cover.spec")               |> String.to_charlist
     label     = Keyword.get(options, :name, default_label)                      |> String.to_charlist
     include   = Keyword.get(options, :include, @default_includes |> Enum.join(","))
 
@@ -80,7 +81,7 @@ defmodule Mix.Tasks.Ct do
       include
       |> String.split(",")
       |> Enum.map(fn x -> 
-        "#{cwd}/#{x}" |> String.to_charlist 
+        "#{child_cwd}/#{x}" |> String.to_charlist 
       end)
 
     result = :ct.run_test([

--- a/lib/mix/tasks/ct.ex
+++ b/lib/mix/tasks/ct.ex
@@ -101,12 +101,10 @@ defmodule Mix.Tasks.Ct do
     case result do
       {:error, _} ->
         Mix.raise("Tests errored upon start")
-        :erlang.halt(1)
       {:ok, failed, {user_skipped, _auto_skipped}} ->
         Mix.raise("Test failures detected")
-        :erlang.halt(if (failed + user_skipped) == 0, do: 0, else: 1)
       _ ->
-        :erlang.halt(0)
+        :ok
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Ejabberd.Mixfile do
 
      # Configuration for using this as an umbrella child app.
      build_path: "../../ebin",
-     #config_path: "../../config/config.exs",
+     config_path: "../../config/config.exs",
      deps_path: "../../deps",  # TODO: might need to fix deps_include in the future.
      lockfile: "../../mix.lock",
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Ejabberd.Mixfile do
+defmodule Ejabberd.MixProject do
   use Mix.Project
 
   def project do
@@ -11,11 +11,19 @@ defmodule Ejabberd.Mixfile do
      compilers: [:asn1] ++ Mix.compilers,
      erlc_options: erlc_options(),
      erlc_paths: ["asn1", "src"],
-     # Elixir tests are starting the part of ejabberd they need
-     aliases: [test: "ct"],
-     package: package(),
      deps: deps(),
-     build_path: "ebin",
+     package: package(),
+
+     # Re-aliasing this to use the ct mix task.
+     aliases: [test: "ct"],
+
+     # Configuration for using this as an umbrella child app.
+     build_path: "../../ebin",
+     config_path: "../../config/config.exs",
+     deps_path: "../../deps",  # TODO: might need to fix deps_include in the future.
+     lockfile: "../../mix.lock",
+
+     # Coveralls specific configuration
      preferred_cli_env: [
        coveralls: :test, 
        "coveralls.json": :test
@@ -23,6 +31,7 @@ defmodule Ejabberd.Mixfile do
      test_coverage: [tool: ExCoveralls, test_task: "ct"],
      cover_enabled: true,
      cover_export_enabled: true]
+
   end
 
   def description do

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Ejabberd.MixProject do
+defmodule Ejabberd.Mixfile do
   use Mix.Project
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Ejabberd.MixProject do
 
      # Configuration for using this as an umbrella child app.
      build_path: "../../ebin",
-     config_path: "../../config/config.exs",
+     #config_path: "../../config/config.exs",
      deps_path: "../../deps",  # TODO: might need to fix deps_include in the future.
      lockfile: "../../mix.lock",
 


### PR DESCRIPTION
We are going to be using mix under the context of a child app in an umbrella project.  This PR does that, and fixes the `ct` task to reflect its new position.  

`     child_cwd = "#{cwd}/apps/ejabberd" # TODO: kind of a hack.  this should be fixed forsure.`
This is a slight hack that I don't know how to fix.  Its not the most awful thing in the world, but if we change the directory structure then it'll be a hassle.

`File.mkdir("#{child_cwd}/ebin")` is needed because ct complains that there needs to be a local ebin directory, even though it runs with it being empty.

@hacctarr 
@dawsonz17 