### PR TITLE
[ES-2614] Adding back auth hacks temporarily

### DIFF
--- a/src/ejabberd_auth.erl
+++ b/src/ejabberd_auth.erl
@@ -584,23 +584,32 @@ db_set_password(User, Server, Password, Mod) ->
 
 db_get_password(User, Server, Mod) ->
     UseCache = use_cache(Mod, Server),
-    case erlang:function_exported(Mod, get_password, 2) of
-	false when UseCache ->
-	    case ets_cache:lookup(?AUTH_CACHE, {User, Server}) of
-		{ok, exists} -> error;
-		Other -> Other
-	    end;
-	false ->
+    case Mod == ejabberd_auth_http of
+    true ->
 	    error;
-	true when UseCache ->
-	    ets_cache:lookup(
-	      ?AUTH_CACHE, {User, Server},
-	      fun() -> Mod:get_password(User, Server) end);
-	true ->
-	    Mod:get_password(User, Server)
+    false ->
+		case erlang:function_exported(Mod, get_password, 2) of
+		false when UseCache ->
+			case ets_cache:lookup(?AUTH_CACHE, {User, Server}) of
+			{ok, exists} -> error;
+			Other -> Other
+			end;
+		false ->
+			error;
+		true when UseCache ->
+			ets_cache:lookup(
+			  ?AUTH_CACHE, {User, Server},
+			  fun() -> Mod:get_password(User, Server) end);
+		true ->
+			Mod:get_password(User, Server)
+        end
     end.
 
 db_user_exists(User, Server, Mod) ->
+	case Mod == ejabberd_auth_http of
+	    true ->
+			Mod:user_exists(User, Server);
+	    false ->
     case db_get_password(User, Server, Mod) of
 	{ok, _} ->
 	    true;
@@ -628,10 +637,15 @@ db_user_exists(User, Server, Mod) ->
 		_ ->
 		    false
 	    end
+	end
     end.
 
 db_check_password(User, AuthzId, Server, ProvidedPassword,
 		  Digest, DigestFun, Mod) ->
+	case Mod == ejabberd_auth_http of
+		true ->
+			Mod:check_password(User, AuthzId, Server, ProvidedPassword);
+		false ->
     case db_get_password(User, Server, Mod) of
 	{ok, ValidPassword} ->
 	    match_passwords(ProvidedPassword, ValidPassword, Digest, DigestFun);
@@ -659,6 +673,7 @@ db_check_password(User, AuthzId, Server, ProvidedPassword,
 		_ ->
 		    false
 	    end
+		end
     end.
 
 db_remove_user(User, Server, Mod) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -956,9 +956,14 @@ is_behaviour(Behav, Mod) ->
 v_db(Mod, internal) -> v_db(Mod, mnesia);
 v_db(Mod, odbc) -> v_db(Mod, sql);
 v_db(Mod, Type) ->
+	case Type == http of
+		true ->
+			Type;
+		false ->
     case ets:member(ejabberd_db_modules, {Mod, Type}) of
 	true -> Type;
 	false -> erlang:error(badarg)
+	end
     end.
 
 -spec v_dbs(module()) -> [atom()].


### PR DESCRIPTION
## The Issue
Roster (eg friend requests) isn't working.  This is because auth is failing for a second user.  this could be because we are mixing internal auth and external auth (eg authing inside of ejabberd and authing against TS) because cas isn't an actual user.  This mixing is causing actual user auth to fail, preventing friend requests from actually going through.

## The Fix
The coded added is emulating this pr that was not included in the 19.02 upgrade because it is hacky: https://github.com/skillz/ejabberd/commit/0f3c9dcb12e265b5582e957c70bfc7bd799c6b41

Going to try it out and investigate a better way of doing auth after.

@hacctarr 
@dawsonz17 