### PR TITLE
[ES-2614] Adjusting sql to delete invalid roster states

### DIFF
--- a/sql/2019-05-02-remove-outbound-friend-requests.sql
+++ b/sql/2019-05-02-remove-outbound-friend-requests.sql
@@ -9,4 +9,4 @@ DELETE FROM
 WHERE
     ask != "N"
     AND subscription != "B"
-    AND (created_at BETWEEN "2019-04-08 00:00:00" AND "2019-04-24 00:00:00");
+    AND (created_at >= "2019-04-08 00:00:00");


### PR DESCRIPTION
This sql will now delete rosters from when the initial friend request P0 came in to the present day.

@hacctarr 
@dawsonz17 