### PR TITLE
[ES-2230] Fixing mix error with config path

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Ejabberd.Mixfile do
 
      # Configuration for using this as an umbrella child app.
      build_path: "../../ebin",
-     config_path: "../../config/config.exs",
+     config_path: get_config_path(),
      deps_path: "../../deps",  # TODO: might need to fix deps_include in the future.
      lockfile: "../../mix.lock",
 
@@ -165,6 +165,14 @@ defmodule Ejabberd.Mixfile do
     end
   end
 
+  # Check if we're in a mix umbrella or not to check for our configuration
+  def get_config_path do
+    if File.exists?("../../config/config.exs") do
+      "../../config/config.exs"
+    else
+      "config/config.exs"
+    end
+  end
 end
 
 defmodule Mix.Tasks.Compile.Asn1 do

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Ejabberd.Mixfile do
+defmodule Ejabberd.MixProject do
   use Mix.Project
 
   def project do


### PR DESCRIPTION
We are in a hybrid state where ejabberd can either be in an umbrella, OR be stand alone (our current official build process).

To prevent build fails for the primary build mechanism I'm adding a check that looks for the umbrella config file.  Otherwise, use the old, ejabberd config.

@hacctarr 
@dawsonz17 