### PR TITLE
[ES-2230] Updating test .yml to use updated certfile options

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Ejabberd.MixProject do
   def application do
     [mod: {:ejabberd_app, []},
      applications: [:kernel, :stdlib, :sasl, :ssl],
-     included_applications: [:lager, :mnesia, :inets, :p1_utils, :cache_tab,
+     included_applications: [:logger, :mnesia, :inets, :p1_utils, :cache_tab,
                              :fast_tls, :stringprep, :fast_xml, :xmpp,
                              :stun, :fast_yaml, :esip, :jiffy, :p1_oauth2,
                              :base64url, :jose, :pkix, :os_mon]

--- a/test/ejabberd_SUITE_data/ejabberd.yml
+++ b/test/ejabberd_SUITE_data/ejabberd.yml
@@ -458,14 +458,16 @@ acl:
 define_macro: 
   CERTFILE: "cert.pem"
   CAFILE: "ca.pem"
+
+certfiles:
+  - CERTFILE
+  - CAFILE
 language: "en"
 listen: 
   - 
     port: @@c2s_port@@
     module: ejabberd_c2s
     max_stanza_size: 65536
-    certfile: CERTFILE
-    cafile: CAFILE
     zlib: true
     starttls: true
     tls_verify: true
@@ -511,9 +513,7 @@ Welcome to this XMPP server."
   mod_version: []
 registration_timeout: infinity
 route_subdomains: s2s
-domain_certfile: CERTFILE
 s2s_use_starttls: false
-s2s_cafile: CAFILE
 outgoing_s2s_port: @@s2s_port@@
 shaper: 
   fast: 50000


### PR DESCRIPTION
Changing this to use more recent certfile configs and also adjusting logger to use the Elixir Logger instead of lager, as it seems tests become unhappy with just lager.

@hacctarr 
@dawsonz17 