### PR TITLE
[ES-1637] Adjusting cert configs to use fully qualified paths

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Ejabberd.MixProject do
   def application do
     [mod: {:ejabberd_app, []},
      applications: [:kernel, :stdlib, :sasl, :ssl],
-     included_applications: [:lager, :mnesia, :inets, :p1_utils, :cache_tab,
+     included_applications: [:logger, :mnesia, :inets, :p1_utils, :cache_tab,
                              :fast_tls, :stringprep, :fast_xml, :xmpp,
                              :stun, :fast_yaml, :esip, :jiffy, :p1_oauth2,
                              :base64url, :jose, :pkix, :os_mon]

--- a/test/ejabberd_SUITE_data/ejabberd.yml
+++ b/test/ejabberd_SUITE_data/ejabberd.yml
@@ -456,8 +456,8 @@ acl:
   local: 
     user_regexp: ""
 define_macro: 
-  CERTFILE: "cert.pem"
-  CAFILE: "ca.pem"
+  CERTFILE: "@@certfile@@"
+  CAFILE: "@@cafile@@"
 language: "en"
 listen: 
   - 

--- a/test/suite.erl
+++ b/test/suite.erl
@@ -70,6 +70,8 @@ init_config(Config) ->
                                                     {pgsql_db, <<"ejabberd_test">>},
                                                     {pgsql_user, <<"ejabberd_test">>},
                                                     {pgsql_pass, <<"ejabberd_test">>},
+                                                    {certfile, CertFile},
+                                                    {cafile, CAFile},
 						    {priv_dir, PrivDir}
 						   ]),
     HostTypes = re:split(CfgContent, "(\\s*- \"(.*)\\.localhost\")",


### PR DESCRIPTION
Okay, the issue before is that when running from the chat-service these config values did not have the correct path, they'd look under `chat-service/ca.pem` for example, instead of `chat-service/logs/xxx/ca.pem`.  Now we are going to use the actual ca.pem and cert.pem file path and use previously utilized substitution methods to take care of this.

@dawsonz17 
@hacctarr 