### PR TITLE
[PS-6075] Add server side mute/ban and a global affiliation table

### DIFF
--- a/include/mod_muc_room.hrl
+++ b/include/mod_muc_room.hrl
@@ -69,7 +69,7 @@
 -type config() :: #config{}.
 
 -type role() :: moderator | participant | visitor | none.
--type affiliation() :: admin | member | outcast | owner | none.
+-type affiliation() :: admin | member | outcast | muted | owner | none.
 
 -record(user,
 {

--- a/sql/2019-07-26-19-user-affiliation-table.sql
+++ b/sql/2019-07-26-19-user-affiliation-table.sql
@@ -7,12 +7,12 @@ CREATE TABLE user_affiliation (
    version       BIGINT        NOT NULL,
    enabled       BIT DEFAULT 1 NOT NULL,
    user_id       BIGINT        NOT NULL,
-   affiliation   VARCHAR(255)  NOT NULL,
+   affiliation   VARCHAR(255)  NOT NULL COLLATE utf8mb4_unicode_ci,
    date_created  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-   last_updated  DATETIME      NOT NULL,
+   last_updated  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
    PRIMARY KEY(id),
-   INDEX user_affiliation_id_enabled_idx (user_id, enabled),
+   INDEX user_affiliation_enabled_id_idx (enabled, user_Id),
    INDEX user_affiliation_date_created_idx (date_created)
 )
 ENGINE = InnoDB
-DEFAULT CHARSET = utf8;
+DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/sql/2019-07-26-19-user-affiliation-table.sql
+++ b/sql/2019-07-26-19-user-affiliation-table.sql
@@ -11,7 +11,7 @@ CREATE TABLE user_affiliation (
    date_created  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
    last_updated  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
    PRIMARY KEY(id),
-   INDEX user_affiliation_enabled_id_idx (enabled, user_Id),
+   INDEX user_affiliation_enabled_id_idx (enabled, user_id),
    INDEX user_affiliation_date_created_idx (date_created)
 )
 ENGINE = InnoDB

--- a/sql/2019-07-26-19-user-affiliation-table.sql
+++ b/sql/2019-07-26-19-user-affiliation-table.sql
@@ -1,0 +1,18 @@
+/**
+  * This is an SQL migration to allow storage of affiliations globally rather than per-muc-room.
+  * Data will be back-filled from chat_user_quarantine after the code is changed to read/write from this table.
+  **/
+CREATE TABLE user_affiliation (
+   id            BIGINT        NOT NULL AUTO_INCREMENT,
+   version       BIGINT        NOT NULL,
+   enabled       BIT DEFAULT 1 NOT NULL,
+   user_id       BIGINT        NOT NULL,
+   affiliation   VARCHAR(255)  NOT NULL,
+   date_created  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+   last_updated  DATETIME      NOT NULL,
+   PRIMARY KEY(id),
+   INDEX user_affiliation_id_enabled_idx (user_id, enabled),
+   INDEX user_affiliation_date_created_idx (date_created)
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = utf8;

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -255,12 +255,11 @@ init([Host, Opts]) ->
     % Create a new ets cache and load it with data from the user_affiliation sql table
     CacheOpts = [{max_size, infinity}, {cache_missed, false}, {life_time, infinity}],
     ets_cache:new(user_affiliation_cache, CacheOpts),
-    {ok, Affiliations} = Mod:get_affiliations(Host),
     AddToCache = fun(UserAffiliation) ->
         {UserId, Affiliation} = UserAffiliation,
-        ets_cache:insert(user_affiliation_cache, list_to_binary(integer_to_list(UserId)), Mod:decode_affiliation(Affiliation))
+        ets_cache:insert(user_affiliation_cache, integer_to_binary(UserId), Mod:decode_affiliation(Affiliation))
     end,
-    lists:foreach(AddToCache, Affiliations),
+    lists:foreach(AddToCache, Mod:get_affiliations(Host)),
     {ok, State}.
 
 handle_call(stop, _From, State) ->

--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -158,7 +158,7 @@ get_affiliations(_ServerHost, _Room, _Host) ->
     {error, not_implemented}.
 
 get_affiliations(_Host) ->
-    {error, not_implemented}.
+    [].
 
 insert_affiliation(_Host, _LUser, _Affiliation) ->
     {error, not_implemented}.

--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -36,7 +36,7 @@
 	 count_online_rooms_by_user/3, get_online_rooms_by_user/3,
 	 get_subscribed_rooms/3]).
 -export([set_affiliation/6, set_affiliations/4, get_affiliation/5,
-	 get_affiliations/3, get_affliations/1, search_affiliation/4,
+	 get_affiliations/3, get_affiliations/1, search_affiliation/4,
 	 disable_affiliation/2, insert_affiliation/3]).
 %% gen_server callbacks
 -export([start_link/2, init/1, handle_cast/2, handle_call/3, handle_info/2,

--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -36,7 +36,8 @@
 	 count_online_rooms_by_user/3, get_online_rooms_by_user/3,
 	 get_subscribed_rooms/3]).
 -export([set_affiliation/6, set_affiliations/4, get_affiliation/5,
-	 get_affiliations/3, search_affiliation/4]).
+	 get_affiliations/3, get_affliations/1, search_affiliation/4,
+	 disable_affiliation/2, insert_affiliation/3]).
 %% gen_server callbacks
 -export([start_link/2, init/1, handle_cast/2, handle_call/3, handle_info/2,
 	 terminate/2, code_change/3]).
@@ -154,6 +155,15 @@ get_affiliation(_ServerHost, _Room, _Host, _LUser, _LServer) ->
     {error, not_implemented}.
 
 get_affiliations(_ServerHost, _Room, _Host) ->
+    {error, not_implemented}.
+
+get_affiliations(_Host) ->
+    {error, not_implemented}.
+
+insert_affiliation(_Host, _LUser, _Affiliation) ->
+    {error, not_implemented}.
+
+disable_affiliation(_Host, _LUser) ->
     {error, not_implemented}.
 
 search_affiliation(_ServerHost, _Room, _Host, _Affiliation) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1332,7 +1332,7 @@ set_affiliation(JID, Affiliation, StateData, Reason) ->
         _ ->
             ok
         end;
-     _ ->
+    _ ->
         case ets_cache:lookup(user_affiliation_cache, LUser) of
         {ok, ExistingAffiliation} ->
             Mod:disable_affiliation(ServerHost, LUser),

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1328,8 +1328,7 @@ set_affiliation(JID, Affiliation, StateData, Reason) ->
     none ->
         case ets_cache:lookup(user_affiliation_cache, LUser) of
         {ok, ExistingAffiliation} ->
-            Mod:disable_affiliation(ServerHost, LUser),
-            ets_cache:delete(user_affiliation_cache, LUser);
+            Mod:disable_affiliation(ServerHost, LUser);
         _ ->
             ok
         end;
@@ -1337,11 +1336,9 @@ set_affiliation(JID, Affiliation, StateData, Reason) ->
         case ets_cache:lookup(user_affiliation_cache, LUser) of
         {ok, ExistingAffiliation} ->
             Mod:disable_affiliation(ServerHost, LUser),
-            Mod:insert_affiliation(ServerHost, LUser, list_to_binary(atom_to_list(NewAffiliation))),
-            ets_cache:update(user_affiliation_cache, LUser, {ok, NewAffiliation}, fun() -> ok end);
+            Mod:insert_affiliation(ServerHost, LUser, NewAffiliation);
         _ ->
-            Mod:insert_affiliation(ServerHost, LUser, list_to_binary(atom_to_list(NewAffiliation))),
-            ets_cache:insert(user_affiliation_cache, LUser, NewAffiliation)
+            Mod:insert_affiliation(ServerHost, LUser, NewAffiliation)
         end
     end,
     StateData.

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -245,18 +245,28 @@ decode_affiliation(<<"outcast">>) -> outcast;
 decode_affiliation(<<"muted">>) -> muted;
 decode_affiliation(_) -> none.
 
-disable_affiliation(_Host, _LUser) ->
-    ejabberd_sql:sql_query(_Host,
+-spec encode_affiliation(Arg :: atom()) -> binary().
+encode_affiliation(owner) -> <<"owner">>;
+encode_affiliation(member) -> <<"member">>;
+encode_affiliation(outcast) -> <<"outcast">>;
+encode_affiliation(muted) -> <<"muted">>;
+encode_affiliation(_) -> <<"none">>.
+
+disable_affiliation(Host, LUser) ->
+    ejabberd_sql:sql_query(Host,
         ?SQL("update user_affiliation "
         "set version = version + 1, enabled = 0, last_updated = now() "
-        "where user_id = %(_LUser)d and enabled = 1")),
+        "where user_id = %(LUser)d and enabled = 1")),
+    ets_cache:delete(user_affiliation_cache, LUser),
     ok.
 
-insert_affiliation(_Host, _LUser, _Affiliation) ->
-    ejabberd_sql:sql_query(_Host,
-            ?SQL("insert into user_affiliation "
-            "(version, enabled, user_id, affiliation, date_created, last_updated) "
-            "values (0, 1, %(_LUser)d, %(_Affiliation)s, now(), now())")),
+insert_affiliation(Host, LUser, Affiliation) ->
+    AffiliationBinary = encode_affiliation(Affiliation),
+    ejabberd_sql:sql_query(Host,
+        ?SQL("insert into user_affiliation "
+        "(version, enabled, user_id, affiliation, date_created, last_updated) "
+        "values (0, 1, %(LUser)d, %(AffiliationBinary)s, now(), now())")),
+    ets_cache:update(user_affiliation_cache, LUser, {ok, Affiliation}, fun() -> ok end),
     ok.
 
 set_affiliation(_ServerHost, _Room, _Host, _JID, _Affiliation, _Reason) ->
@@ -268,15 +278,15 @@ set_affiliations(_ServerHost, _Room, _Host, _Affiliations) ->
 get_affiliation(_ServerHost, _Room, _Host, _LUser, _LServer) ->
     {error, not_implemented}.
 
-get_affiliations(_Host) ->
-    case ejabberd_sql:sql_query(_Host,
+get_affiliations(Host) ->
+    case ejabberd_sql:sql_query(Host,
             ?SQL("select @(user_id)d, @(affiliation)s "
                  "from user_affiliation "
-                 "where enabled=1")) of
+                 "where enabled = 1")) of
         {selected, Affiliations} ->
-            {ok, Affiliations};
+            Affiliations;
         _ ->
-            {ok, []}
+            []
         end.
 
 get_affiliations(_ServerHost, _Room, _Host) ->

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -283,11 +283,11 @@ get_affiliations(Host) ->
             ?SQL("select @(user_id)d, @(affiliation)s "
                  "from user_affiliation "
                  "where enabled = 1")) of
-        {selected, Affiliations} ->
-            Affiliations;
-        _ ->
-            []
-        end.
+    {selected, Affiliations} ->
+        Affiliations;
+    _ ->
+        []
+    end.
 
 get_affiliations(_ServerHost, _Room, _Host) ->
     {error, not_implemented}.

--- a/test/docker/db/mysql/initdb/mysql.sql
+++ b/test/docker/db/mysql/initdb/mysql.sql
@@ -473,7 +473,7 @@ CREATE TABLE user_affiliation (
    date_created  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
    last_updated  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
    PRIMARY KEY(id),
-   INDEX user_affiliation_enabled_id_idx (enabled, user_Id),
+   INDEX user_affiliation_enabled_id_idx (enabled, user_id),
    INDEX user_affiliation_date_created_idx (date_created)
 )
 ENGINE = InnoDB

--- a/test/docker/db/mysql/initdb/mysql.sql
+++ b/test/docker/db/mysql/initdb/mysql.sql
@@ -463,3 +463,19 @@ CREATE TABLE mqtt_pub (
     expiry int unsigned NOT NULL,
     UNIQUE KEY i_mqtt_topic (topic(191))
 );
+
+CREATE TABLE user_affiliation (
+   id            BIGINT        NOT NULL AUTO_INCREMENT,
+   version       BIGINT        NOT NULL,
+   enabled       BIT DEFAULT 1 NOT NULL,
+   user_id       BIGINT        NOT NULL,
+   affiliation   VARCHAR(255)  NOT NULL COLLATE utf8mb4_unicode_ci,
+   date_created  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+   last_updated  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+   PRIMARY KEY(id),
+   INDEX user_affiliation_enabled_id_idx (enabled, user_Id),
+   INDEX user_affiliation_date_created_idx (date_created)
+)
+ENGINE = InnoDB
+DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+


### PR DESCRIPTION
This PR adds support for persisting global server-side mutes and bans.

Some small background is that Ejabberd has built-in support for persisted banning via the `Outcast affiliation`, and built-in support for muting (although it is not persisted) via the `visitor role`. These are both stored in the StateData of each muc_room, which is counter-intuitive to our platform. We would like bans/mutes to be persisted and global.

This was accomplished by:
1. Adding a new sql table called user_affiliation, which maps user_id -> affiliation
2. Adding an ets_cache to quickly fetch the affiliation for any user, warmed at startup from the sql table. 
3. Adding a new affiliation called `muted` so that we can persist mutes
4. Assigning a user role to `visitor` when joining a room if their affiliation is `muted`
5. When assigning affiliations, if we receive a change to `outcast` with a reason of `muted`, we actually assign to the new `muted` affiliation. This is to allow use of the new affiliation using the existing XMPP protocol.

CAS side that makes use of these changes: https://github.com/skillz/chat-administration-service/pull/86
@aghchan @arlene-enero @mpope9 @leejona16 