### PR TITLE
[PS-7793] Set role to visitor on outcast affiliation change

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1318,9 +1318,15 @@ set_affiliation(JID, Affiliation, StateData, Reason) ->
     Host = StateData#state.host,
     Mod = gen_mod:db_mod(ServerHost, mod_muc),
     LUser = JID#jid.luser,
+    RoomJID = StateData#state.jid,
+    To = jid:replace_resource(RoomJID, LUser),
     NewAffiliation = case {Affiliation, Reason} of
     {outcast, <<"muted">>} ->
+        set_role(To, visitor, StateData),
         muted;
+    {outcast, _} ->
+        set_role(To, visitor, StateData),
+        Affiliation;
     _ ->
         Affiliation
     end,


### PR DESCRIPTION
Locally, my XMPP client is auto kicked when affiliation is changed to outcast.

When testing on QA, I discovered that the SDK does not auto-kick, and this bug originated by users seemingly avoiding the kick_session command. 

This ensures that if the user is banned/muted, but somehow manages to stay in the room, they at least will be set to visitor and cannot talk. 

My previous solution was to only set the role on room join, but if the user is already in a room and avoids the kick, they were able to talk still when muted/banned

@mpope9 @aghchan @arlene-enero 
