### PR TITLE
[PS-7793] Set role to visitor when affiliation changed to outcast

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1318,15 +1318,9 @@ set_affiliation(JID, Affiliation, StateData, Reason) ->
     Host = StateData#state.host,
     Mod = gen_mod:db_mod(ServerHost, mod_muc),
     LUser = JID#jid.luser,
-    RoomJID = StateData#state.jid,
-    To = jid:replace_resource(RoomJID, LUser),
     NewAffiliation = case {Affiliation, Reason} of
     {outcast, <<"muted">>} ->
-        set_role(To, visitor, StateData),
         muted;
-    {outcast, _} ->
-        set_role(To, visitor, StateData),
-        Affiliation;
     _ ->
         Affiliation
     end,
@@ -2818,7 +2812,7 @@ process_item_change(Item, SD, UJID) ->
 	    {JID, affiliation, outcast, Reason} ->
 		send_kickban_presence(UJID, JID, Reason, 301, outcast, SD),
 		maybe_send_affiliation(JID, outcast, SD),
-		set_affiliation(JID, outcast, set_role(JID, none, SD), Reason);
+		set_affiliation(JID, outcast, set_role(JID, visitor, SD), Reason);
 	    {JID, affiliation, A, Reason} when (A == admin) or (A == owner) ->
 		SD1 = set_affiliation(JID, A, SD, Reason),
 		SD2 = set_role(JID, moderator, SD1),


### PR DESCRIPTION
I did not properly return the result of set_role in my last PR, as set_role does not actually do anything besides return an updated StateData.

I have found a cleaner way, however, because by default the role gets set to none when a user is outcasted. Instead, we can set to visitor at that point. That value is passed in as StateData to set_affiliation, and subsequently returned.

I was able to test this locally by commenting out the send_kickban_presence (which is respected by my XMPP client but ignored by the SDK) so that I could stay in the room and show that I am a visitor that cannot speak

@mpope9 @aghchan @arlene-enero 