### PR TITLE
[PS-7793] Enable decreasing owner affiliation

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2956,7 +2956,9 @@ can_change_ra(_FAffiliation, _FRole, owner, _TRole,
 can_change_ra(_FAffiliation, _FRole, _TAffiliation,
 	      _TRole, _RoleorAffiliation, _Value, owner) ->
     %% Nobody can decrease MUC admin's role/affiliation
-    false;
+    %% But because we allow users to create MUC rooms (DMs), and they must be owners to do this,
+    %% we must allow decreasing the affiliation of an owner in order to ban/mute users that have created DMs
+    true;
 can_change_ra(_FAffiliation, _FRole, TAffiliation,
 	      _TRole, affiliation, Value, _ServiceAf)
     when TAffiliation == Value ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2955,7 +2955,7 @@ can_change_ra(_FAffiliation, _FRole, owner, _TRole,
     true;
 can_change_ra(_FAffiliation, _FRole, _TAffiliation,
 	      _TRole, _RoleorAffiliation, _Value, owner) ->
-    %% Nobody can decrease MUC admin's role/affiliation
+    %% Originally, nobody could decrease MUC admin's role/affiliation
     %% But because we allow users to create MUC rooms (DMs), and they must be owners to do this,
     %% we must allow decreasing the affiliation of an owner in order to ban/mute users that have created DMs
     true;


### PR DESCRIPTION
For context this was not able to be tested before because DMs were broken in general due to a permission issue. After fixing that issue, I discovered 1 more issue:
If a user has created a DM, they can no longer be banned/muted by skillz-cas

This is because there is a line that restricts decreasing the affiliation of owners.

Because we allow users to create their own MUC rooms, and each user must be an owner of their own MUC room in order to create the room, any user that creates a DM (or group chat) will be considered an owner.

This fix is to ensure that skillz-cas has the ability to decrease the affiliation of users that have created DMs

@david-thornton717 