### PR TITLE
[PS-8252] Enable adjusting affiliation for users that have created a DM

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3043,6 +3043,9 @@ can_change_ra(owner, _FRole, owner, _TRole, affiliation,
     check_owner;
 can_change_ra(_FAffiliation, _FRole, _TAffiliation,
 	      _TRole, affiliation, _Value, _ServiceAf) ->
+	% Originally, this returned false
+	% We require this to return true in order to ban users that have created DMs
+	% and are owners of their own room
     true;
 can_change_ra(_FAffiliation, moderator, _TAffiliation,
 	      visitor, role, none, _ServiceAf) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3043,9 +3043,9 @@ can_change_ra(owner, _FRole, owner, _TRole, affiliation,
     check_owner;
 can_change_ra(_FAffiliation, _FRole, _TAffiliation,
 	      _TRole, affiliation, _Value, _ServiceAf) ->
-	% Originally, this returned false
-	% We require this to return true in order to ban users that have created DMs
-	% and are owners of their own room
+    % Originally, this returned false
+    % We require this to return true in order to ban users that have created DMs
+    % and are owners of their own room
     true;
 can_change_ra(_FAffiliation, moderator, _TAffiliation,
 	      visitor, role, none, _ServiceAf) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3043,8 +3043,7 @@ can_change_ra(owner, _FRole, owner, _TRole, affiliation,
     check_owner;
 can_change_ra(_FAffiliation, _FRole, _TAffiliation,
 	      _TRole, affiliation, _Value, _ServiceAf) ->
-    ?ERROR_MSG("ra failed on line 3046", []),
-    false;
+    true;
 can_change_ra(_FAffiliation, moderator, _TAffiliation,
 	      visitor, role, none, _ServiceAf) ->
     true;


### PR DESCRIPTION
Added logs at each point along the path where can_change_ra failed, and found that when a user has created a DM and is the owner, this is the point where it fails.

I have left the logs in the other fail cases in case they still fail after setting this to true.

@mpope9 @leejona16 