### PR TITLE
[PS-8252] Remove local affiliation cache

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -252,14 +252,6 @@ init([Host, Opts]) ->
 %	      load_permanent_rooms(MyHost, Host, Access, HistorySize,
 %				   RoomShaper, QueueType)
       end, MyHosts),
-    % Create a new ets cache and load it with data from the user_affiliation sql table
-    CacheOpts = [{max_size, infinity}, {cache_missed, false}, {life_time, infinity}],
-    ets_cache:new(user_affiliation_cache, CacheOpts),
-    AddToCache = fun(UserAffiliation) ->
-        {Nick, Affiliation} = UserAffiliation,
-        ets_cache:insert(user_affiliation_cache, Nick, Mod:decode_affiliation(Affiliation))
-    end,
-    lists:foreach(AddToCache, Mod:get_affiliations(Host)),
     {ok, State}.
 
 handle_call(stop, _From, State) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1330,20 +1330,10 @@ set_affiliation(JID, Affiliation, StateData, Reason) ->
         end,
         case NewAffiliation of
         none ->
-            case ets_cache:lookup(user_affiliation_cache, LUser) of
-            {ok, ExistingAffiliation} ->
-                Mod:disable_affiliation(ServerHost, LUser);
-            _ ->
-                ok
-            end;
+            Mod:disable_affiliation(ServerHost, LUser);
         _ ->
-            case ets_cache:lookup(user_affiliation_cache, LUser) of
-            {ok, ExistingAffiliation} ->
-                Mod:disable_affiliation(ServerHost, LUser),
-                Mod:insert_affiliation(ServerHost, LUser, NewAffiliation);
-            _ ->
-                Mod:insert_affiliation(ServerHost, LUser, NewAffiliation)
-            end
+            Mod:disable_affiliation(ServerHost, LUser),
+            Mod:insert_affiliation(ServerHost, LUser, NewAffiliation)
         end
     end,
     StateData.
@@ -1408,12 +1398,7 @@ do_get_affiliation(JID, StateData) ->
         LUser = JID#jid.luser,
         ServerHost = StateData#state.server_host,
         Mod = gen_mod:db_mod(ServerHost, mod_muc),
-        case ets_cache:lookup(user_affiliation_cache, LUser) of
-        {ok, Affiliation} ->
-            Affiliation;
-        _ ->
-            none
-        end
+        Mod:get_affiliation(ServerHost, LUser)
     end.
 
 -spec do_get_affiliation_fallback(jid(), state()) -> affiliation().


### PR DESCRIPTION
Context: Realized that the ets_cache in use here is node-specific.

I began adding logic to fallback to sql on cache miss, but then I realized that the following scenario would break it:
1. cas connects to chatbox1
2. cas bans user on chatbox1
3. cas DCs and connects to chatbox2
4. cas unbans user on chatbox2
5. cas DCs and connects to chatbox1
6. cas now believes that the user is banned because chatbox1 still has the banned affiliation in the cache. It will not be a cache miss, so the fallback would not save us here

The long-term solution is to use a distributed cache. The options here are Mnesia or Redis, where I'm leaning toward using mnesia with sync writes for bans, dirty_writes for unbans. I have a story in the backlog to fix this

In the meantime, we simply always hit the sql table.
This is not the worst, but its certainly not ideal. 
1. there are only 100 active quarantines in prod
2. we have an index on nick, enabled that should make this sufficiently fast for the time being

@mpope9 @aghchan @leejona16 