### PR TITLE
Feature add kubernetes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 .win32
 .examples
+kubernetes

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN mix deps.get \
 # Clean up chat service module sources
 RUN rm -rf /opt/chat-service/.ejabberd-modules/sources
 
+
 FROM alpine AS runtime
 
 # Install required dependencies
@@ -99,11 +100,14 @@ COPY --from=builder /usr/local/lib/erlang/lib/p1_utils_iconv-* /usr/local/lib/er
 # Install chat service
 WORKDIR /opt/chat-service
 COPY --from=builder /opt/chat-service .
+COPY --from=builder /tmp/chat-service/scripts scripts
 
 USER ejabberd
 WORKDIR /home/ejabberd
 
+ENV EJABBERD_HOME /opt/chat-service
+ENV EJABBERDCTL /opt/chat-service/sbin/ejabberdctl
+
 EXPOSE 1883 4369-4399 5222 5269 5280 5443
 
-ENTRYPOINT ["/opt/chat-service/sbin/ejabberdctl"]
-CMD ["foreground"]
+ENTRYPOINT ["/opt/chat-service/scripts/run.sh"]

--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chat-service
+  namespace: server
+  labels:
+    app: chat-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chat-service
+  template:
+    metadata:
+      labels:
+        app: chat-service
+    spec:
+      containers:
+      - image: localhost:5000/ejabberd-dev:latest
+        name: chat-service
+        ports:
+        - containerPort: 5280
+          name: http
+        - containerPort: 5269
+          name: s2s-in
+        - containerPort: 5222
+          name: c2s
+        resources: {}

--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: chat-service
     spec:
       containers:
-      - image: localhost:5000/ejabberd-dev:latest
+      - image: docker.dev.skillz.com:5000/ejabberd:latest
         name: chat-service
         envFrom:
         - secretRef:

--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: chat-service
-  namespace: server
   labels:
     app: chat-service
 spec:
@@ -18,6 +17,9 @@ spec:
       containers:
       - image: localhost:5000/ejabberd-dev:latest
         name: chat-service
+        envFrom:
+        - secretRef:
+            name: chat-service-users
         ports:
         - containerPort: 5280
           name: http

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- namespace.yaml
+- deployment.yaml
+- service.yaml

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -1,4 +1,6 @@
+namespace: server
 resources:
 - namespace.yaml
+- secret.yaml
 - deployment.yaml
 - service.yaml

--- a/kubernetes/base/namespace.yaml
+++ b/kubernetes/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: server

--- a/kubernetes/base/secret.yaml
+++ b/kubernetes/base/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chat-service-users
+type: Opaque
+data:
+  CHAT_SERVICE_USERS: YWRtaW5AbG9jYWxob3N0OnBhc3N3b3Jk

--- a/kubernetes/base/service.yaml
+++ b/kubernetes/base/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: chat-service
+  name: chat-service
+  namespace: server
+spec:
+  selector:
+    app: chat-service
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 5280
+    targetPort: http
+  - name: s2s-in
+    port: 5269
+    targetPort: s2s-in
+  - name: c2s
+    port: 5222
+    targetPort: c2s

--- a/kubernetes/base/service.yaml
+++ b/kubernetes/base/service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: chat-service
   name: chat-service
-  namespace: server
 spec:
   selector:
     app: chat-service

--- a/scripts/create_users.sh
+++ b/scripts/create_users.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Do not exit if users already registered
+set +e
+
+register_user() {
+    local user=$1
+    local domain=$2
+    local password=$3
+
+    ${EJABBERDCTL} register ${user} ${domain} ${password}
+}
+
+# register users from environment $CHAT_SERVICE_USERS with given password.
+# Use whitespace to separate users.
+register_all_users() {
+    for user in ${CHAT_SERVICE_USERS} ; do
+        local jid=${user%%:*}
+        local password=${user#*:}
+
+        local username=${jid%%@*}
+        local domain=${jid#*@}
+
+        [[ "${password}" == "${jid}" ]] \
+            && password=$(randpw)
+
+        register_user ${username} ${domain} ${password}
+    done
+}
+
+# Register users if the environment variable exists
+[ -n "${CHAT_SERVICE_USERS}" ] \
+    && register_all_users
+
+exit 0

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Start chat service in the background
+exec ${EJABBERDCTL} "foreground" &
+child=$!
+${EJABBERDCTL} started
+
+# Run post startup scripts
+${EJABBERD_HOME}/scripts/create_users.sh
+
+wait $child


### PR DESCRIPTION
Added kubernetes manifests for ejabberd/chat service.

Chose a single replica deployment over a statefulset because we'll be setting up the mnesia database as an external resource in a future pull request. It's not worth our time to temporarily create a statefulset and then completely shift over to deployment later.

Added a script that automatically creates users in ejabberd if you pass the information in via environment variable. Format is `myuser@domain:mypassword anotheruser@anotherdomain:mypassword`.

Confirmed that an XMPP client (Spark) on the desktop was able to connect to the chat service running in minikube. You just have to go to advanced setting, uncheck "Automatically discover host and port", and then put in the host and port that `minikube service` gives you. That host and port needs to point to the c2s port. After that, username is `admin`, password is `password` -- we can change this later.

@thePhilGuy 