### PR TITLE
[ES-4115] Added configuration overlays to the kubernetes manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,33 +52,33 @@ RUN ./autogen.sh \
     && make && make install
 
 # Build chat service modules
-RUN mkdir -p /opt/chat-service/.ejabberd-modules/sources
+WORKDIR /home/ejabberd
+RUN mkdir -p .ejabberd-modules/sources
 RUN mix local.hex --force \
     && mix local.rebar --force
 
 # Module push skillz
-WORKDIR /opt/chat-service/.ejabberd-modules/sources
+WORKDIR /home/ejabberd/.ejabberd-modules/sources
 COPY .ejabberd_modules/sources/mod_push_skillz mod_push_skillz
-WORKDIR /opt/chat-service/.ejabberd-modules/sources/mod_push_skillz
+WORKDIR /home/ejabberd/.ejabberd-modules/sources/mod_push_skillz
 RUN mix deps.get \
     && mix module_install ModPushSkillz
 
 # Module pottymouth
-WORKDIR /opt/chat-service/.ejabberd-modules/sources
+WORKDIR /home/ejabberd/.ejabberd-modules/sources
 COPY .ejabberd_modules/sources/mod_pottymouth mod_pottymouth
-WORKDIR /opt/chat-service/.ejabberd-modules/sources/mod_pottymouth
+WORKDIR /home/ejabberd/.ejabberd-modules/sources/mod_pottymouth
 RUN mix deps.get \
     && mix module_install ModPottymouth
 
 # Module beam stats
-WORKDIR /opt/chat-service/.ejabberd-modules/sources
+WORKDIR /home/ejabberd/.ejabberd-modules/sources
 COPY .ejabberd_modules/sources/mod_beam_stats mod_beam_stats
-WORKDIR /opt/chat-service/.ejabberd-modules/sources/mod_beam_stats
+WORKDIR /home/ejabberd/.ejabberd-modules/sources/mod_beam_stats
 RUN mix deps.get \
     && mix module_install ModBeamStats
 
-# Clean up chat service module sources
-RUN rm -rf /opt/chat-service/.ejabberd-modules/sources
+RUN ls /home/ejabberd/.ejabberd-modules
 
 
 FROM alpine AS runtime
@@ -101,9 +101,11 @@ COPY --from=builder /usr/local/lib/erlang/lib/p1_utils_iconv-* /usr/local/lib/er
 WORKDIR /opt/chat-service
 COPY --from=builder /opt/chat-service .
 COPY --from=builder /tmp/chat-service/scripts scripts
+WORKDIR /home/ejabberd/.ejabberd-modules
+COPY --from=builder /home/ejabberd/.ejabberd-modules .
 
-USER ejabberd
 WORKDIR /home/ejabberd
+USER ejabberd
 
 ENV EJABBERD_HOME /opt/chat-service
 ENV EJABBERDCTL /opt/chat-service/sbin/ejabberdctl

--- a/kubernetes/base/config/access-control-lists.yml
+++ b/kubernetes/base/config/access-control-lists.yml
@@ -1,0 +1,15 @@
+###.   ====================
+###'   ACCESS CONTROL LISTS
+acl:
+  ##
+  ## The 'admin' ACL grants administrative privileges to XMPP accounts.
+  ## You can put here as many accounts as you want.
+  ##
+  local:
+    user_regexp: ""
+  loopback:
+    ip:
+      - "127.0.0.0/8"
+  admin:
+    user:
+      - skillz-cas: chat-admin.dev.skillz.com

--- a/kubernetes/base/config/access-rules.yml
+++ b/kubernetes/base/config/access-rules.yml
@@ -1,0 +1,36 @@
+###.  ============
+###'  ACCESS RULES
+access_rules:
+  ## This rule allows access only for local users:
+  local:
+    - allow: local
+  ## Only non-blocked users can use c2s connections:
+  c2s:
+    - deny: blocked
+    - allow
+  ## Only admins can send announcement messages:
+  announce:
+    - allow: admin
+  ## Only admins can use the configuration interface:
+  configure:
+    - allow: admin
+  ## Only accounts of the local ejabberd server can create rooms:
+  muc_create:
+    - allow: local
+  ## Only accounts on the local ejabberd server can create Pubsub nodes:
+  ## pubsub_createnode:
+  ##  - allow: local
+  ## In-band registration allows registration of any possible username.
+  ## To disable in-band registration, replace 'allow' with 'deny'.
+  register:
+    - deny
+  ## Only allow to register from localhost
+  trusted_network:
+    - allow: loopback
+  ## Do not establish S2S connections with bad servers
+  ## s2s:
+  ##   - deny:
+  ##     - ip: "XXX.XXX.XXX.XXX/32"
+  ##   - deny:
+  ##     - ip: "XXX.XXX.XXX.XXX/32"
+  ##   - allow

--- a/kubernetes/base/config/api-permissions.yml
+++ b/kubernetes/base/config/api-permissions.yml
@@ -1,0 +1,65 @@
+## ===============
+## API PERMISSIONS
+## ===============
+##
+## This section allows you to define who and using what method
+## can execute commands offered by ejabberd.
+##
+## By default "console commands" section allow executing all commands
+## issued using ejabberdctl command, and "admin access" section allows
+## users in admin acl that connect from 127.0.0.1 to  execute all
+## commands except start and stop with any available access method
+## (ejabberdctl, http-api, xmlrpc depending what is enabled on server).
+##
+## If you remove "console commands" there will be one added by
+## default allowing executing all commands, but if you just change
+## permissions in it, version from config file will be used instead
+## of default one.
+##
+api_permissions:
+  "admin access":
+    who:
+      - access:
+        - allow:
+          - ip: "0.0.0.0/0"
+    what:
+      - "send_stanza"
+      - "kick_session"
+      - "set_room_affiliation"
+      - "get_online_rooms"
+      - "get_room_occupants"
+      - "destroy_room"
+      - "get_room_options"
+
+shaper:
+  ##
+  ## The "normal" shaper limits traffic speed to 1000 B/s
+  ##
+  normal: 1000
+
+  ##
+  ## The "fast" shaper limits traffic speed to 50000 B/s
+  ##
+  fast: 50000
+
+##
+## This option specifies the maximum number of elements in the queue
+## of the FSM. Refer to the documentation for details.
+##
+max_fsm_queue: 1000
+
+# ACL rules managed by the ejabberd::user defined type
+
+shaper_rules:
+  ## Maximum number of simultaneous sessions allowed for a single user:
+  max_user_sessions: 10
+  ## Maximum number of offline messages that users can have:
+  max_user_offline_messages:
+    - 5000: admin
+    - 100
+  ## For C2S connections, all users except admins use the "normal" shaper
+  c2s_shaper:
+    - none: admin
+    - normal
+  ## All S2S connections use the "fast" shaper
+  s2s_shaper: fast

--- a/kubernetes/base/config/ejabberd.yml
+++ b/kubernetes/base/config/ejabberd.yml
@@ -1,0 +1,26 @@
+language: "en"
+allow_contrib_modules: true
+
+# Log
+include_config_file: /opt/chat-service/etc/ejabberd/log.yml
+
+# Hosts
+include_config_file: /opt/chat-service/etc/ejabberd/hosts.yml
+
+# Listen
+include_config_file: /opt/chat-service/etc/ejabberd/listen.yml
+
+# Authentication
+include_config_file: /opt/chat-service/etc/ejabberd/authentication.yml
+
+# API Permissions
+include_config_file: /opt/chat-service/etc/ejabberd/api-permissions.yml
+
+# Access Rules
+include_config_file: /opt/chat-service/etc/ejabberd/access-rules.yml
+
+# Access Control Lists
+include_config_file: /opt/chat-service/etc/ejabberd/access-control-lists.yml
+
+# Modules
+include_config_file: /opt/chat-service/etc/ejabberd/modules.yml

--- a/kubernetes/base/config/ejabberdctl.cfg
+++ b/kubernetes/base/config/ejabberdctl.cfg
@@ -1,0 +1,182 @@
+#
+# In this file you can configure options that are passed by ejabberdctl
+# to the erlang runtime system when starting ejabberd
+#
+
+#' POLL: Kernel polling ([true|false])
+#
+# The kernel polling option requires support in the kernel.
+# Additionally, you need to enable this feature while compiling Erlang.
+#
+# Default: true
+#
+#POLL=true
+
+#.
+#' SMP: SMP support ([enable|auto|disable])
+#
+# Explanation in Erlang/OTP documentation:
+# enable: starts the Erlang runtime system with SMP support enabled.
+#   This may fail if no runtime system with SMP support is available.
+# auto: starts the Erlang runtime system with SMP support enabled if it
+#   is available and more than one logical processor are detected.
+# disable: starts a runtime system without SMP support.
+#
+# Default: auto
+#
+#SMP=auto
+
+#.
+#' ERL_MAX_PORTS: Maximum number of simultaneously open Erlang ports
+#
+# ejabberd consumes two or three ports for every connection, either
+# from a client or from another Jabber server. So take this into
+# account when setting this limit.
+#
+# Default: 65536 (or 8196 on Windows)
+# Maximum: 268435456
+#
+#ERL_MAX_PORTS=65536
+
+#.
+#' FIREWALL_WINDOW: Range of allowed ports to pass through a firewall
+#
+# If Ejabberd is configured to run in cluster, and a firewall is blocking ports,
+# it's possible to make Erlang use a defined range of port (instead of dynamic
+# ports) for node communication.
+#
+# Default: not defined
+# Example: 4200-4210
+#
+#FIREWALL_WINDOW=
+
+#.
+#' INET_DIST_INTERFACE: IP address where this Erlang node listens other nodes
+#
+# This communication is used by ejabberdctl command line tool,
+# and in a cluster of several ejabberd nodes.
+#
+# Default: 0.0.0.0
+#
+#INET_DIST_INTERFACE=127.0.0.1
+
+#.
+#' ERL_EPMD_ADDRESS: IP addresses where epmd listens for connections
+#
+# IMPORTANT: This option works only in Erlang/OTP R14B03 and newer.
+#
+# This environment variable may be set to a comma-separated
+# list of IP addresses, in which case the epmd daemon
+# will listen only on the specified address(es) and on the
+# loopback address (which is implicitly added to the list if it
+# has not been specified). The default behaviour is to listen on
+# all available IP addresses.
+#
+# Default: 0.0.0.0
+#
+#ERL_EPMD_ADDRESS=127.0.0.1
+
+#.
+#' ERL_PROCESSES: Maximum number of Erlang processes
+#
+# Erlang consumes a lot of lightweight processes. If there is a lot of activity
+# on ejabberd so that the maximum number of processes is reached, people will
+# experience greater latency times. As these processes are implemented in
+# Erlang, and therefore not related to the operating system processes, you do
+# not have to worry about allowing a huge number of them.
+#
+# Default: 262144
+# Maximum: 268435456
+#
+#ERL_PROCESSES=262144
+
+#.
+#' ERL_MAX_ETS_TABLES: Maximum number of ETS and Mnesia tables
+#
+# The number of concurrent ETS and Mnesia tables is limited. When the limit is
+# reached, errors will appear in the logs:
+#   ** Too many db tables **
+# You can safely increase this limit when starting ejabberd. It impacts memory
+# consumption but the difference will be quite small.
+#
+# Default: 2053
+#
+#ERL_MAX_ETS_TABLES=2053
+
+#.
+#' ERL_OPTIONS: Additional Erlang options
+#
+# The next variable allows to specify additional options passed to erlang while
+# starting ejabberd. Some useful options are -noshell, -detached, -heart. When
+# ejabberd is started from an init.d script options -noshell and -detached are
+# added implicitly. See erl(1) for more info.
+#
+# It might be useful to add "-pa /usr/local/lib/ejabberd/ebin" if you
+# want to add local modules in this path.
+#
+# Default: ""
+#
+#ERL_OPTIONS=""
+
+#.
+#' ERLANG_NODE: Erlang node name
+#
+# The next variable allows to explicitly specify erlang node for ejabberd
+# It can be given in different formats:
+# ERLANG_NODE=ejabberd
+#   Lets erlang add hostname to the node (ejabberd uses short name in this case)
+# ERLANG_NODE=ejabberd@hostname
+#   Erlang uses node name as is (so make sure that hostname is a real
+#   machine hostname or you'll not be able to control ejabberd)
+# ERLANG_NODE=ejabberd@hostname.domainname
+#   The same as previous, but erlang will use long hostname
+#   (see erl (1) manual for details)
+#
+# Default: ejabberd@localhost
+#
+#ERLANG_NODE=ejabberd@localhost
+
+#.
+#' EJABBERD_PID_PATH: ejabberd PID file
+#
+# Indicate the full path to the ejabberd Process identifier (PID) file.
+# If this variable is defined, ejabberd writes the PID file when starts,
+# and deletes it when stops.
+# Remember to create the directory and grant write permission to ejabberd.
+#
+# Default: don't write PID file
+#
+#EJABBERD_PID_PATH=/var/run/ejabberd/ejabberd.pid
+
+#.
+#' EJABBERD_CONFIG_PATH: ejabberd configuration file
+#
+# Specify the full path to the ejabberd configuration file. If the file name has
+# yml or yaml extension, it is parsed as a YAML file; otherwise, Erlang syntax is
+# expected.
+#
+# Default: $ETC_DIR/ejabberd.yml
+#
+#EJABBERD_CONFIG_PATH=/etc/ejabberd/ejabberd.yml
+
+#.
+#' CONTRIB_MODULES_PATH: contributed ejabberd modules path
+#
+# Specify the full path to the contributed ejabberd modules. If the path is not
+# defined, ejabberd will use ~/.ejabberd-modules in home of user running ejabberd.
+#
+# Default: $HOME/.ejabberd-modules
+#
+#CONTRIB_MODULES_PATH=/opt/ejabberd-modules
+
+#.
+#' CONTRIB_MODULES_CONF_DIR: configuration directory for contributed modules
+#
+# Specify the full path to the configuration directory for contributed ejabberd
+# modules. In order to configure a module named mod_foo, a mod_foo.yml file can
+# be created in this directory. This file will then be used instead of the
+# default configuration file provided with the module.
+#
+# Default: $CONTRIB_MODULES_PATH/conf
+#
+#CONTRIB_MODULES_CONF_DIR=/etc/ejabberd/modules

--- a/kubernetes/base/config/hosts.yml
+++ b/kubernetes/base/config/hosts.yml
@@ -1,0 +1,3 @@
+hosts:
+  - "chat.dev.skillz.com"
+  - "chat-admin.dev.skillz.com"

--- a/kubernetes/base/config/inetrc
+++ b/kubernetes/base/config/inetrc
@@ -1,0 +1,3 @@
+{lookup,["file","native"]}.
+{host,{127,0,0,1}, ["localhost","hostalias"]}.
+{file, resolv, "/etc/resolv.conf"}.

--- a/kubernetes/base/config/listen.yml
+++ b/kubernetes/base/config/listen.yml
@@ -1,0 +1,34 @@
+listen:
+  - 
+    port: 5222
+    module: ejabberd_c2s
+    starttls: true
+    starttls_required: false
+    tls_compression: false
+    protocol_options:
+      - "no_sslv2"
+      - "no_sslv3"
+      - "no_tlsv1"
+      - "no_tlsv1_1"
+    ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+    max_stanza_size: 65536
+    shaper: c2s_shaper
+    access: c2s
+  - 
+    port: 5269
+    module: ejabberd_s2s_in
+    max_stanza_size: 131072
+    shaper: s2s_shaper
+  -
+    port: 5280
+    module: ejabberd_http
+    request_handlers:
+      "/websocket": ejabberd_http_ws
+    http_bind: true
+  -
+    port: 5290
+    module: ejabberd_http
+    web_admin: true
+    request_handlers:
+      "/api": mod_http_api
+    http_bind: true

--- a/kubernetes/base/config/log.yml
+++ b/kubernetes/base/config/log.yml
@@ -1,0 +1,7 @@
+loglevel: 5
+
+log_rotate_size: 524288000
+log_rotate_date: "$D23"
+log_rotate_count: 30
+
+log_rate_limit: 100

--- a/kubernetes/base/config/modules.yml
+++ b/kubernetes/base/config/modules.yml
@@ -1,0 +1,70 @@
+##
+## Modules enabled in all ejabberd virtual hosts.
+##
+modules:
+  mod_blocking: {} # requires mod_privacy
+  mod_disco: {}
+  mod_pres_counter:
+    count: 100
+    interval: 60
+  mod_privacy: {}
+  mod_vcard:
+    search: true
+  ModBeamStats: {}
+  mod_pottymouth:
+    blacklists:
+      default: /home/ejabberd/.ejabberd-modules/sources/mod_pottymouth/blacklist/blacklist_en.txt
+      en: /home/ejabberd/.ejabberd-modules/sources/mod_pottymouth/blacklist/blacklist_en.txt
+  ModPushSkillz:
+    rabbit_url: "amqp://skillz-user:REDACTED@rabbit.qa.skillz.com:5672/skillz"
+  mod_admin_extra: {}
+  mod_fail2ban:
+    c2s_auth_ban_lifetime: 10
+    c2s_max_auth_failures: 200
+  mod_http_bind: {}
+  mod_mam: {}
+  mod_metrics: {}
+  mod_muc:
+    access:
+    - allow
+    access_admin:
+      allow: admin
+    access_create: muc_create
+    access_persistent: muc_create
+    history_size: 200
+    max_users: 10000
+    max_user_conferences: 50
+    max_room_id: 1024
+    max_room_name: 1024
+    max_room_desc: 2048
+    min_message_interval: 0.4
+    min_presence_interval: 4
+    max_users_presence: 200
+    default_room_options:
+      allow_change_subj: false
+      allow_private_messages: true
+      allow_query_users: false
+      allow_visitor_status: false
+      anonymous: true
+      captcha_protected: false
+      logging: true
+      mam: true
+      max_users: 10000
+      members_by_default: true
+      members_only: false
+      moderated: true
+      password_protected: false
+      persistent: true
+      public: true
+      public_list: false
+      presence_broadcast: {}
+  mod_muc_admin: {}
+  mod_offline:
+    access_max_user_messages: max_user_offline_messages
+  mod_ping: {}
+  mod_private:
+    use_cache: false
+  mod_register:
+    ip_access: trusted_network
+    access: register
+  mod_roster: {}

--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       containers:
       - image: docker.dev.skillz.com:5000/ejabberd:latest
+        imagePullPolicy: Never
         name: chat-service
         envFrom:
         - secretRef:
@@ -28,3 +29,56 @@ spec:
         - containerPort: 5222
           name: c2s
         resources: {}
+        readinessProbe:
+          tcpSocket:
+            port: c2s
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        livenessProbe:
+          tcpSocket:
+            port: c2s
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        # Switch to using a projected volume (https://kubernetes.io/docs/concepts/storage/volumes/#projected) once the feature comes out of beta
+        volumeMounts:
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/ejabberdctl.cfg
+            subPath: ejabberdctl.cfg
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/inetrc
+            subPath: inetrc
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/ejabberd.yml
+            subPath: ejabberd.yml
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/log.yml
+            subPath: log.yml
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/hosts.yml
+            subPath: hosts.yml
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/listen.yml
+            subPath: listen.yml
+          - name: ejabberd-config-secret
+            mountPath: /opt/chat-service/etc/ejabberd/authentication.yml
+            subPath: authentication.yml
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/api-permissions.yml
+            subPath: api-permissions.yml
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/access-rules.yml
+            subPath: access-rules.yml
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/access-control-lists.yml
+            subPath: access-control-lists.yml
+          - name: ejabberd-config
+            mountPath: /opt/chat-service/etc/ejabberd/modules.yml
+            subPath: modules.yml
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: ejabberd-config
+        configMap:
+          name: ejabberd-config
+      - name: ejabberd-config-secret
+        secret:
+          secretName: ejabberd-config-secret

--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -16,7 +16,6 @@ spec:
     spec:
       containers:
       - image: docker.dev.skillz.com:5000/ejabberd:latest
-        imagePullPolicy: Never
         name: chat-service
         envFrom:
         - secretRef:

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -4,3 +4,20 @@ resources:
 - secret.yaml
 - deployment.yaml
 - service.yaml
+configMapGenerator:
+- name: ejabberd-config
+  files:
+  - config/ejabberdctl.cfg
+  - config/inetrc
+  - config/ejabberd.yml
+  - config/log.yml
+  - config/hosts.yml
+  - config/listen.yml
+  - config/api-permissions.yml
+  - config/access-rules.yml
+  - config/access-control-lists.yml
+  - config/modules.yml
+secretGenerator:
+- name: ejabberd-config-secret
+  files:
+  - secret/authentication.yml

--- a/kubernetes/base/secret/authentication.yml
+++ b/kubernetes/base/secret/authentication.yml
@@ -1,0 +1,37 @@
+###.  ==============
+###'  AUTHENTICATION
+
+##
+## auth_method: Method used to authenticate the users.
+## The default method is the internal.
+## If you want to use a different method,
+## comment this line and enable the correct ones.
+##
+## We have two hosts, one for admin and one for users.  They have different auth methods.
+
+auth_use_cache: false
+append_host_config:
+  "chat-admin.dev.skillz.com":
+    auth_method: internal
+
+append_host_config:
+  "chat.dev.skillz.com":
+    auth_method: http
+    auth_opts:
+      host: "http://api-gateway-internal.localhost:10010"
+      connection_pool_size: 8
+      connection_opts: []
+      path_prefix: "/chat-auth/"
+
+default_db: sql
+
+sql_type: mysql
+sql_server: "mysql-ejabberd.dev.skillz.com"
+
+sql_port: 3306
+sql_database: "REDACTED"
+sql_username: "REDACTED"
+sql_password: "REDACTED"
+sql_keepalive_interval: 60
+sql_start_interval: 5
+sql_pool_size: 10

--- a/kubernetes/overlays/qa/config/access-control-lists.yml
+++ b/kubernetes/overlays/qa/config/access-control-lists.yml
@@ -1,0 +1,15 @@
+###.   ====================
+###'   ACCESS CONTROL LISTS
+acl:
+  ##
+  ## The 'admin' ACL grants administrative privileges to XMPP accounts.
+  ## You can put here as many accounts as you want.
+  ##
+  local:
+    user_regexp: ""
+  loopback:
+    ip:
+      - "127.0.0.0/8"
+  admin:
+    user:
+      - skillz-cas: chat-admin.qa.skillz.com

--- a/kubernetes/overlays/qa/config/hosts.yml
+++ b/kubernetes/overlays/qa/config/hosts.yml
@@ -1,0 +1,3 @@
+hosts:
+  - "chat.qa.skillz.com"
+  - "chat-admin.qa.skillz.com"

--- a/kubernetes/overlays/qa/kustomization.yaml
+++ b/kubernetes/overlays/qa/kustomization.yaml
@@ -1,0 +1,14 @@
+namespace: server
+bases:
+- ../../base
+configMapGenerator:
+- name: ejabberd-config
+  behavior: merge
+  files:
+  - config/hosts.yml
+  - config/access-control-lists.yml
+secretGenerator:
+- name: ejabberd-config-secret
+  behavior: merge
+  files:
+  - secret/authentication.yml

--- a/kubernetes/overlays/qa/secret/authentication.yml
+++ b/kubernetes/overlays/qa/secret/authentication.yml
@@ -1,0 +1,37 @@
+###.  ==============
+###'  AUTHENTICATION
+
+##
+## auth_method: Method used to authenticate the users.
+## The default method is the internal.
+## If you want to use a different method,
+## comment this line and enable the correct ones.
+##
+## We have two hosts, one for admin and one for users.  They have different auth methods.
+
+auth_use_cache: false
+append_host_config:
+  "chat-admin.qa.skillz.com":
+    auth_method: internal
+
+append_host_config:
+  "chat.qa.skillz.com":
+    auth_method: http
+    auth_opts:
+      host: "http://api-gateway-internal.islay:10010"
+      connection_pool_size: 8
+      connection_opts: []
+      path_prefix: "/chat-auth/"
+
+default_db: sql
+
+sql_type: mysql
+sql_server: "mysql-ejabberd.qa.skillz.com"
+
+sql_port: 3306
+sql_database: "REDACTED"
+sql_username: "REDACTED"
+sql_password: "REDACTED"
+sql_keepalive_interval: 60
+sql_start_interval: 5
+sql_pool_size: 10

--- a/kubernetes/overlays/staging/config/access-control-lists.yml
+++ b/kubernetes/overlays/staging/config/access-control-lists.yml
@@ -1,0 +1,15 @@
+###.   ====================
+###'   ACCESS CONTROL LISTS
+acl:
+  ##
+  ## The 'admin' ACL grants administrative privileges to XMPP accounts.
+  ## You can put here as many accounts as you want.
+  ##
+  local:
+    user_regexp: ""
+  loopback:
+    ip:
+      - "127.0.0.0/8"
+  admin:
+    user:
+      - skillz-cas: chat-admin.staging.skillz.com

--- a/kubernetes/overlays/staging/config/hosts.yml
+++ b/kubernetes/overlays/staging/config/hosts.yml
@@ -1,0 +1,3 @@
+hosts:
+  - "chat.staging.skillz.com"
+  - "chat-admin.staging.skillz.com"

--- a/kubernetes/overlays/staging/kustomization.yaml
+++ b/kubernetes/overlays/staging/kustomization.yaml
@@ -1,0 +1,14 @@
+namespace: server
+bases:
+- ../../base
+configMapGenerator:
+- name: ejabberd-config
+  behavior: merge
+  files:
+  - config/hosts.yml
+  - config/access-control-lists.yml
+secretGenerator:
+- name: ejabberd-config-secret
+  behavior: merge
+  files:
+  - secret/authentication.yml

--- a/kubernetes/overlays/staging/secret/authentication.yml
+++ b/kubernetes/overlays/staging/secret/authentication.yml
@@ -1,0 +1,38 @@
+###.  ==============
+###'  AUTHENTICATION
+
+##
+## auth_method: Method used to authenticate the users.
+## The default method is the internal.
+## If you want to use a different method,
+## comment this line and enable the correct ones.
+##
+## We have two hosts, one for admin and one for users.  They have different auth methods.
+
+auth_use_cache: false
+append_host_config:
+  "chat-admin.staging.skillz.com":
+    auth_method: internal
+
+append_host_config:
+  "chat.staging.skillz.com":
+    auth_method: http
+    auth_opts:
+      host: "http://api-gateway-internal.speyside:10010"
+      connection_pool_size: 12
+      connection_opts: []
+      basic_auth: "REDACTED"
+      path_prefix: "/chat-auth/"
+
+default_db: sql
+
+sql_type: mysql
+sql_server: "mysql-ejabberd.staging.skillz.com"
+
+sql_port: 3306
+sql_database: "REDACTED"
+sql_username: "REDACTED"
+sql_password: "REDACTED"
+sql_keepalive_interval: 60
+sql_start_interval: 5
+sql_pool_size: 10


### PR DESCRIPTION
Added configuration overlays by leveraging configMapGenerator from kustomize. This solves the problem of making sure a change to the configmap triggers a rolling update and allows us to overlay files on top of each other for different environments.

Had to modify the Dockerfile as well, as it turns out that ejabberd doesn't like where I put the ejabberd modules. It wants those in the home directory of the user that's running the node. We may be able to change that later via configuration options but I didn't see a quick and way to do so.

@thePhilGuy 