### PR TITLE
[ES-4113] Added test execution for mod push skillz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ FROM alpine AS builder
 
 ARG REBAR_VERSION=2.6.4
 ARG ICONV_VERSION=1.0.10
-ENV MIX_ENV dev
 
 # Install required dependencies from package manager
 RUN apk upgrade --update musl \
@@ -61,6 +60,9 @@ RUN mix local.hex --force \
 WORKDIR /home/ejabberd/.ejabberd-modules/sources
 COPY .ejabberd_modules/sources/mod_push_skillz mod_push_skillz
 WORKDIR /home/ejabberd/.ejabberd-modules/sources/mod_push_skillz
+RUN export MIX_ENV=test \
+    && mix deps.get \
+    && mix test
 RUN mix deps.get \
     && mix module_install ModPushSkillz
 
@@ -77,8 +79,6 @@ COPY .ejabberd_modules/sources/mod_beam_stats mod_beam_stats
 WORKDIR /home/ejabberd/.ejabberd-modules/sources/mod_beam_stats
 RUN mix deps.get \
     && mix module_install ModBeamStats
-
-RUN ls /home/ejabberd/.ejabberd-modules
 
 
 FROM alpine AS runtime


### PR DESCRIPTION
Added a section to the dockerfile for running tests for mod_push_skillz. Other modules either had failing tests (mod_beam_stats) or try to start running themselves during the test (mod_pottymouth).

Removed the global `MIX_ENV` since it's not actually useful.

Ejabberd itself doesn't have any tests that get run in Jenkins, so I didn't dig any deeper. Unfortunately that was all I could accomplish in the timebox.

@thePhilGuy 