### PR TITLE
[PS-4816] Speed up MAM query by removing the use of count(*) on archive table

### DIFF
--- a/src/mod_mam_sql.erl
+++ b/src/mod_mam_sql.erl
@@ -187,9 +187,8 @@ select(LServer, JidRequestor, #jid{luser = LUser} = JidArchive,
     % and the client did not specify a limit using RSM then the server should
     % return a policy-violation error to the client." We currently don't do this
     % for v0.2 requests, but we do limit #rsm_in.max for v0.3 and newer.
-    case {ejabberd_sql:sql_query(LServer, Query),
-	  ejabberd_sql:sql_query(LServer, CountQuery)} of
-	{{selected, _, Res}, {selected, _, [[Count]]}} ->
+    case {ejabberd_sql:sql_query(LServer, Query), CountQuery} of
+	{{selected, _, Res}, _} ->
 	    {Max, Direction, _} = get_max_direction_id(RSM),
 	    {Res1, IsComplete} =
 		if Max >= 0 andalso Max /= undefined andalso length(Res) > Max ->
@@ -211,7 +210,7 @@ select(LServer, JidRequestor, #jid{luser = LUser} = JidArchive,
 			   {error, _} ->
 			       []
 		       end
-	       end, Res1), IsComplete, binary_to_integer(Count)};
+	       end, Res1), IsComplete, 50};
 	_ ->
 	    {[], false, 0}
     end.


### PR DESCRIPTION
 Hardcoding the result of the count(*) to 50. 

This breaks the ability to do ResultSet paging on MAM commands, however we do not make use of MAM for any purpose and there is no reason to support getting the middle of the archive for our use case.

count(*) on a table with 7m rows was taking over 12s on my local. In prod this table has >=16m rows and will be even worse.

By hardcoding it to 50, the query is now more like ~10ms.

We only query from the lastPage from CAS, and usually with a limit of 5. 

The value of 50 is mostly arbitrary but it allows for us to grab a larger limit later if necessary. 

@aghchan @TomPeng19971208 