### PR TITLE
[PS-12438] No longer remove offline messages on new presence

### DIFF
--- a/src/mod_offline_sql.erl
+++ b/src/mod_offline_sql.erl
@@ -68,7 +68,7 @@ store_message(#offline_msg{us = {LUser, LServer}} = M) ->
     end.
 
 pop_messages(LUser, LServer) ->
-    case get_and_del_spool_msg_t(LServer, LUser) of
+    case get_spool_msg_t(LServer, LUser) of
 	{atomic, {selected, Rs}} ->
 	    {ok, lists:flatmap(
 		   fun({_, XML}) ->
@@ -259,15 +259,12 @@ el_to_offline_msg(El) ->
 	    {error, bad_jid_from}
     end.
 
-get_and_del_spool_msg_t(LServer, LUser) ->
+get_spool_msg_t(LServer, LUser) ->
     F = fun () ->
 		Result =
 		    ejabberd_sql:sql_query_t(
                       ?SQL("select @(username)s, @(xml)s from spool where "
                            "username=%(LUser)s and %(LServer)H order by seq;")),
-		ejabberd_sql:sql_query_t(
-                  ?SQL("delete from spool where"
-                       " username=%(LUser)s and %(LServer)H;")),
 		Result
 	end,
     ejabberd_sql:sql_transaction(LServer, F).


### PR DESCRIPTION
We have been assuming that "offline" messages function as "unread" messages. By design, when you first connect to ejabberd, all offline messages are cleared in the DB. This gives you time to display the fact that you have offline messages, and the next time you login they are gone. 

We want them to act as "unread" messages, which means that we do not clear them until explicitly told by the SDK that the messages have been viewed.

The SDK asks us to remove offline messages at the time of joining a room - DMs, group chats, etc. 

This will now actually act as "unread" messages as we expect!

@aghchan @TomPeng19971208 