### PR TITLE
[PS-15768] Whitelist rooms_unused_destroy endpoint

### DIFF
--- a/kubernetes/base/config/api-permissions.yaml
+++ b/kubernetes/base/config/api-permissions.yaml
@@ -31,6 +31,7 @@ api_permissions:
       - "destroy_room"
       - "get_room_options"
       - "get_roster"
+      - "rooms_unused_destroy"
 
 shaper:
   ##


### PR DESCRIPTION
I had previously whitelisted using puppet-ejabberd (still necessary for production). However, we use Kubernetes now in our QA/Staging environment, which no longer uses puppet.

Instead we need to whitelist via the Kubernetes configs

@aghchan @gschnaubelt 