### PR TITLE
[PS-15155] Remove filtering offline_messages by message_type

### DIFF
--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1536,6 +1536,7 @@ send_stanza(FromString, ToString, Stanza) ->
 			                                    [spoof_muc_state(LServer, To), From#jid.user]),
 		Wrapped       = wrap(To, From, ArchivePacket, ?NS_MUCSUB_NODES_MESSAGES),
 		PacketToSend  = xmpp:set_from_to(Wrapped, To, From),
+		?DEBUG("Running offline_message_hook via send_stanza to an offline room", []),
 		ejabberd_hooks:run_fold(offline_message_hook, LServer, {bounce, PacketToSend}, []),
 		ok
 	end

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4478,8 +4478,10 @@ inspect_sdk_xmlels(User, #xmlel{name = Name, children = ChildrenList}, Acc) ->
     [Children|_] = ChildrenList,
     {_, CData} = Children,
     case Name of
-      <<"user_id">> -> [User == CData|Acc];
-      <<"message_type">> -> [lists:member(binary_to_integer(CData), ?NoOfflineToSenderTypes)|Acc];
+      <<"user_id">> -> [User == CData | Acc];
+      %% TODO: Filtering by message_type is cruft that wasn't working as intended, but it's something we may want to
+      %% reimplement properly in the future, so for now we consider all message_types as potentially ignorable
+      <<"message_type">> -> [true | Acc];
       _ -> Acc
     end;
 inspect_sdk_xmlels(_, _, Acc) -> Acc.
@@ -4491,6 +4493,7 @@ should_send_message(#message{sub_els = SubEls}, #jid{user = User}) ->
     ShouldIgnore = lists:foldl(fun(Child, Acc) ->
         inspect_sdk_xmlels(User, Child, Acc)
     end, [], SdkChildren),
+    ?DEBUG("ShouldIgnore [user_id, message_type]: ~p", [ShouldIgnore]),
     ShouldIgnore /= [true, true].
 
 %% If they are not in the room, and the message_type isn't in the list of


### PR DESCRIPTION
Background:
There is currently a bug where we send double push-notifications for chat-events. This only occurs when a user is "offline" and "not in the room" and then sends a DM to a room. For example, when accepting a friend request (which you do while not in a room), we automatically send "Thanks for adding me" as a chat message to the person that was added. This triggers a push-notification for BOTH users, including the user that sent the "thanks for adding me message". 

Another way to consistently trigger this is to send a chat message from the friends list by clicking on their avatar, rather than entering the chat room.

Matt had actually implemented logic to handle this case, but it is a little bit complicated for what it's doing and assumes that the only ignorable types are nudges and VsFriendsRequests. This leaves out my 2 examples above.

Why this will fix the bug:
We determine whether we should send the offline message by this check:
```
ShouldIgnore = lists:foldl(fun(Child, Acc) ->
        inspect_sdk_xmlels(User, Child, Acc)
    end, [], SdkChildren),
    ?DEBUG("ShouldIgnore [user_id, message_type]: ~p", [ShouldIgnore]),
    ShouldIgnore /= [true, true].
```

ShouldIgnore is an array of booleans: [canIgnoreByUserId, canIgnoreByMessageType]. 

Because normal messages are not defined in the macro `?NoOfflineToSenderTypes`, even if the userID was found to be the same as the sender, `canIgnoreByMessageType` would always be false. 

So, even if we detected we should filter by this UserID, we would end up with ShouldIgnore=`[true, false]`. In Erlang, `/=` is `!=`. So here we check that it does not equal `[true, true]`, which it never can because of the message_type filtering.

Thus, `ShouldIgnore /= [true, true]` is ALWAYS true for DM messages, which means we always send the offline message.

With this change, we essentially hardcode the shouldIgnoreByMessageType to [true]. 

So now, if the UserID in the message is same as the person sending it, we will get `[true, true]` and correctly ignore the offline message.

If the userID in the message is different, we get `[false, true]` and will still send the offline message.

The reason I chose to hardcode this rather than refactor this method entirely is:
1. I don't want to make an overly complicated change to Ejabberd unless we have to right now
2. We might want to reimplement filtering by message_type in the future, but I will need to discuss with product

I also added some additional debug logging so we can doubly verify the impact of this on staging.

@aghchan @gschnaubelt 