### PR TITLE
Use updated git url for base64url dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -102,7 +102,7 @@ defmodule Ejabberd.MixProject do
      {:distillery, "~> 2.0"},
      {:pkix, "~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev},
-     {:base64url, "~> 0.0.1"},
+     {:base64url, tag: "~> 0.0.1", git: "https://github.com/dvv/base64url.git"},
      {:jose, "~> 1.8"},
      {:meck, "0.8.13", only: :test},
      {:excoveralls, "~> 0.11.0", only: :test}]


### PR DESCRIPTION
```
ERROR: sh(git clone -n git://github.com/dvv/base64url.git base64url)
failed with return code 128 and the following output:
Cloning into 'base64url'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

This dep is relying on the git protocol. We should instead query using https like the other dependencies by forcing it here