### PR TITLE
Use updated git url and tag for base64url dep in Rebar and Mix (#176)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -102,7 +102,7 @@ defmodule Ejabberd.MixProject do
      {:distillery, "~> 2.0"},
      {:pkix, "~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev},
-     {:base64url, "~> 0.0.1"},
+     {:base64url, tag: "v1.0", git: "https://github.com/dvv/base64url.git"},
      {:jose, "~> 1.8"},
      {:meck, "0.8.13", only: :test},
      {:excoveralls, "~> 0.11.0", only: :test}]

--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,7 @@
         {jiffy, ".*", {git, "https://github.com/davisp/jiffy", {tag, "1.0.1"}}},
         {p1_oauth2, ".*", {git, "https://github.com/processone/p1_oauth2", {tag, "0.6.4"}}},
         {pkix, ".*", {git, "https://github.com/processone/pkix", {tag, "1.0.1"}}},
+        {base64url, ".*", {git, "https://github.com/dvv/base64url.git", {tag, "v1.0"}}},
         {jose, ".*", {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.8.4"}}},
         {mqtree, ".*", {git, "https://github.com/processone/mqtree", {tag, "1.0.2"}}},
         {if_var_true, stun, {stun, ".*", {git, "https://github.com/processone/stun", {tag, "1.0.27"}}}},


### PR DESCRIPTION
* Use updated git url for base64url dep in Rebar

* Update rebar.config

* Update mix.exs