### PR TITLE
[PS-58628] Direct More Read-Only Queries to Replicas

### DIFF
--- a/src/mod_block_incoming.erl
+++ b/src/mod_block_incoming.erl
@@ -30,7 +30,7 @@
 
 -define(HOOK_PRIORITY, 25).
 
--define(COMMAND_TIMEOUT, timer:seconds(2)).
+-define(COMMAND_TIMEOUT, timer:seconds(5)).
 
 %%%===================================================================
 %%% Callbacks and hooks
@@ -212,16 +212,16 @@ get_config_users_dict(Host) ->
 
 get_blocking_users(Host) ->
   try gen_server:call(get_proc_name(Host), {get_blocking_users}, ?COMMAND_TIMEOUT)
-  catch _:_ ->
-    ?ERROR_MSG("Failed to get blocking users. Falling back to initial list from mod opts.", []),
+  catch TypeOfError:Error ->
+    ?ERROR_MSG("Failed to get blocking users. Falling back to initial list from mod opts. Type of Error: [~p]. Error: [~p].", [TypeOfError, Error]),
     gen_mod:get_module_opt(Host, ?MODULE, blocking_users, [])
   end
 .
 
 is_blocking_user(Host, User) ->
   try gen_server:call(get_proc_name(Host), {is_blocking_user, User}, ?COMMAND_TIMEOUT)
-  catch _:_ ->
-    ?ERROR_MSG("Failed to check if user is blocking. Falling back to false.", []),
+  catch TypeOfError:Error ->
+    ?ERROR_MSG("Failed to check if user is blocking. Falling back to false. Type of Error: [~p]. Error: [~p].", [TypeOfError, Error]),
     false
   end
 .

--- a/src/mod_block_incoming.erl
+++ b/src/mod_block_incoming.erl
@@ -30,7 +30,7 @@
 
 -define(HOOK_PRIORITY, 25).
 
--define(COMMAND_TIMEOUT, timer:seconds(5)).
+-define(COMMAND_TIMEOUT, timer:seconds(2)).
 
 %%%===================================================================
 %%% Callbacks and hooks

--- a/src/mod_mam_sql.erl
+++ b/src/mod_mam_sql.erl
@@ -184,7 +184,7 @@ select(LServer, JidRequestor, #jid{luser = LUser} = JidArchive,
     % and the client did not specify a limit using RSM then the server should
     % return a policy-violation error to the client." We currently don't do this
     % for v0.2 requests, but we do limit #rsm_in.max for v0.3 and newer.
-    case {ejabberd_sql:sql_query(LServer, Query), CountQuery} of
+    case {ejabberd_sql:sql_query(LServer, Query, secondary), CountQuery} of
   {{selected, _, Res}, _} ->
       {Max, Direction, _} = get_max_direction_id(RSM),
       {Res1, IsComplete} =

--- a/src/mod_privacy_sql.erl
+++ b/src/mod_privacy_sql.erl
@@ -319,7 +319,7 @@ get_default_privacy_list(LUser, LServer) ->
     ejabberd_sql:sql_query(
       LServer,
       ?SQL("select @(name)s from privacy_default_list "
-           "where username=%(LUser)s and %(LServer)H")).
+           "where username=%(LUser)s and %(LServer)H"), secondary).
 
 get_default_privacy_list_t(LUser, LServer) ->
     ejabberd_sql:sql_query_t(
@@ -351,7 +351,7 @@ get_privacy_list_data(LUser, LServer, Name) ->
            "where id ="
            " (select id from privacy_list"
            " where username=%(LUser)s and %(LServer)H and name=%(Name)s) "
-           "order by ord")).
+           "order by ord"), secondary).
 
 set_default_privacy_list(LUser, LServer, Name) ->
     ?SQL_UPSERT_T(

--- a/src/mod_roster_sql.erl
+++ b/src/mod_roster_sql.erl
@@ -70,7 +70,7 @@ get_roster(LUser, LServer) ->
 	   ?SQL("select @(username)s, @(jid)s, @(nick)s, @(subscription)s, "
 		"@(ask)s, @(askmessage)s, @(server)s, @(subscribe)s, "
 		"@(type)s from rosterusers "
-                "where username=%(LUser)s and %(LServer)H")) of
+                "where username=%(LUser)s and %(LServer)H"), secondary) of
         {selected, Items} when is_list(Items) ->
             JIDGroups = case get_roster_jid_groups(LServer, LUser) of
                             {selected, JGrps} when is_list(JGrps) ->
@@ -225,7 +225,7 @@ get_roster_jid_groups(LServer, LUser) ->
     ejabberd_sql:sql_query(
       LServer,
       ?SQL("select @(jid)s, @(grp)s from rostergroups where "
-           "username=%(LUser)s and %(LServer)H")).
+           "username=%(LUser)s and %(LServer)H"), secondary).
 
 get_roster_groups(LServer, LUser, SJID) ->
     ejabberd_sql:sql_query_t(

--- a/src/mod_vcard_sql.erl
+++ b/src/mod_vcard_sql.erl
@@ -55,7 +55,7 @@ get_vcard(LUser, LServer) ->
     case ejabberd_sql:sql_query(
 	   LServer,
 	   ?SQL("select @(vcard)s from vcard"
-                " where username=%(LUser)s and %(LServer)H")) of
+                " where username=%(LUser)s and %(LServer)H"), secondary) of
 	{selected, [{SVCARD}]} ->
 	    case fxml_stream:parse_element(SVCARD) of
 		{error, _Reason} -> error;


### PR DESCRIPTION
Direct more read-only queries to replicas. None of these queries are used in explicit transactions that would both read/write. This means they are safe to direct to the replicas bc there is no implied logic requiring that a read should be guaranteed to include something that was just written or that a row being read must be locked until some write completes. These queries also represent the next highest impact on the load of the primary MySQL Ejabberd database.

Along with the above, this PR includes extra logging and a longer command timeout for the mod_block_incoming module used to block friend requests to moderators.