### PR TITLE
[PS-64994] Multi-vcard performance optimization

### DIFF
--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -325,8 +325,19 @@ get_vcard(LUser, LServer) ->
 
 -spec get_vcards(binary(), binary()) -> [{list(), xmlel()}] | error.
 get_vcards(LUsers, LServer) ->
-	Mod = gen_mod:db_mod(LServer, ?MODULE),
-	Mod:get_vcards(LUsers, LServer)
+	VCards = lists:map(fun(LUser) ->
+		{ LUser, get_vcard(LUser, LServer) }
+	end, LUsers),
+	#xmlel{name = <<"vCards">>, attrs = [{<<"xmlns">>, <<"jabber:client">>}], children = [
+		case VCard of
+			error -> #xmlel{
+				name = <<"vCard">>,
+				attrs = [{<<"xmlns">>, <<"jabber:client">>}, {<<"username">>, Username}],
+				children = [ {xmlcdata, <<"error">>} ]
+			};
+			_ -> VCard#xmlel{attrs = VCard#xmlel.attrs ++ [{<<"username">>, Username}]}
+		end || {Username, [VCard]} <- VCards
+	]}
 .
 
 get_vcard_field(LUser, LServer, FieldName) ->


### PR DESCRIPTION
Using a warm cache is much faster than direct DB querying. On a cold cache, larger requests (~100+) is faster going direct to the DB. However, since we have increased cache size, we will almost always have a warm cache.