### PR TITLE
[PS-64548] Fix error in unused cleanup code

### DIFF
--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -838,42 +838,46 @@ decide_rooms(Method, Rooms, ServerHost, Last_allowed) ->
     lists:filter(Decide, Rooms).
 
 decide_room(unused, {_Room_name, _Host, Room_pid}, ServerHost, Last_allowed) ->
-    C = get_room_config(Room_pid),
-    Persistent = C#config.persistent,
+	try
+		case is_process_alive(Room_pid) of
+			true ->
+				C = get_room_config(Room_pid),
+				Persistent = C#config.persistent,
 
-    S = get_room_state(Room_pid),
-    Just_created = S#state.just_created,
+				S = get_room_state(Room_pid),
+				Just_created = S#state.just_created,
 
-    Room_users = S#state.users,
-    Num_users = maps:size(Room_users),
+				Room_users = S#state.users,
+				Num_users = maps:size(Room_users),
 
-    History = (S#state.history)#lqueue.queue,
-    Ts_now = calendar:universal_time(),
-    HistorySize = gen_mod:get_module_opt(ServerHost, mod_muc, history_size),
-    JustCreated = S#state.just_created,
-    {Has_hist, Last} = case p1_queue:is_empty(History) of
-			   true when (HistorySize == 0) or (JustCreated == true) ->
-			       {false, 0};
-			   true ->
-			       Ts_diff = (misc:now_to_usec(now())
-				    - S#state.just_created) div 1000000,
-			       {false, Ts_diff};
-			   false ->
-			       Last_message = get_queue_last(History),
-			       Ts_last = calendar:now_to_universal_time(
-					   element(4, Last_message)),
-			       Ts_diff =
-				   calendar:datetime_to_gregorian_seconds(Ts_now)
-				   - calendar:datetime_to_gregorian_seconds(Ts_last),
-			       {true, Ts_diff}
-		       end,
-    case {Persistent, Just_created, Num_users, Has_hist, seconds_to_days(Last)} of
-	{_true, JC, 0, _, Last_days}
-	when (Last_days >= Last_allowed) and (JC /= true) ->
-	    true;
-	_ ->
-	    false
-    end;
+				History = (S#state.history)#lqueue.queue,
+				Ts_now = calendar:universal_time(),
+				HistorySize = gen_mod:get_module_opt(ServerHost, mod_muc, history_size),
+				JustCreated = S#state.just_created,
+				{Has_hist, Last} = case p1_queue:is_empty(History) of
+						 true when (HistorySize == 0) or (JustCreated == true) ->
+								 {false, 0};
+						 true ->
+								 Ts_diff = (misc:now_to_usec(now())
+								- S#state.just_created) div 1000000,
+								 {false, Ts_diff};
+						 false ->
+								 Last_message = get_queue_last(History),
+								 Ts_last = calendar:now_to_universal_time(
+								 element(4, Last_message)),
+								 Ts_diff = calendar:datetime_to_gregorian_seconds(Ts_now) - calendar:datetime_to_gregorian_seconds(Ts_last),
+								 {true, Ts_diff}
+							 end,
+				case {Persistent, Just_created, Num_users, Has_hist, seconds_to_days(Last)} of
+					{_true, JC, 0, _, Last_days} when (Last_days >= Last_allowed) and (JC /= true) -> true;
+					_ -> false
+				end;
+			_ -> true %% process is not alive, so it is no longer used and may be removed
+		end
+	catch _:_ ->
+		false %% an error occurred so to be safe, do not remove room
+	end
+;
 decide_room(empty, {Room_name, Host, _Room_pid}, ServerHost, _Last_allowed) ->
     case gen_mod:is_loaded(ServerHost, mod_mam) of
 	true ->
@@ -941,8 +945,13 @@ act_on_room(Method, destroy, {N, H, Pid}, SH) ->
 
 act_on_room(Method, destroy_not_forget, {N, H, Pid}, SH) ->
 	Message = iolist_to_binary(io_lib:format(<<"Room destroyed by rooms_~s_destroy.">>, [Method])),
-	p1_fsm:send_all_state_event(Pid, {destroy, Message}),
-	mod_muc:room_destroyed(H, N, Pid, SH)
+	%% catch any errors related to the pid
+	try
+		p1_fsm:send_all_state_event(Pid, {destroy, Message})
+	catch _:_ ->
+		ok
+	end,
+	mod_muc:room_destroyed(H, N, Pid, SH) %% unregister from online rooms list
 ;
 
 act_on_room(_Method, list, _, _) ->


### PR DESCRIPTION
Currently, a single dead pid representing a room can halt the cleanup process for removing unused rooms. The pids are stored in the DB, so it could be that some error or another caused the pid to die before it could be removed from the DB properly. In this case, the job will fail to clean up that room and all others. This PR fixes that by checking if pids are alive and also safely wrapping the whole thing in a try/catch.